### PR TITLE
미션 제출 기능 구현 (issue#29)

### DIFF
--- a/backend/src/main/java/develup/member/Member.java
+++ b/backend/src/main/java/develup/member/Member.java
@@ -12,6 +12,10 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    public Member(Long id) {
+        this.id = id;
+    }
+
     protected Member() {
     }
 

--- a/backend/src/main/java/develup/mission/Language.java
+++ b/backend/src/main/java/develup/mission/Language.java
@@ -1,6 +1,6 @@
 package develup.mission;
 
-enum Language {
+public enum Language {
 
     JAVA, JAVASCRIPT
 }

--- a/backend/src/main/java/develup/mission/MissionRepository.java
+++ b/backend/src/main/java/develup/mission/MissionRepository.java
@@ -2,5 +2,5 @@ package develup.mission;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-interface MissionRepository extends JpaRepository<Mission, Long> {
+public interface MissionRepository extends JpaRepository<Mission, Long> {
 }

--- a/backend/src/main/java/develup/submission/CreateSubmissionRequest.java
+++ b/backend/src/main/java/develup/submission/CreateSubmissionRequest.java
@@ -1,8 +1,15 @@
 package develup.submission;
 
+import develup.member.Member;
+import develup.mission.Mission;
+
 record CreateSubmissionRequest(
         Long missionId,
         String url,
         String comment
 ) {
+
+    public Submission toEntity(Member member, Mission mission) {
+        return new Submission(url, comment, member, mission);
+    }
 }

--- a/backend/src/main/java/develup/submission/CreateSubmissionRequest.java
+++ b/backend/src/main/java/develup/submission/CreateSubmissionRequest.java
@@ -1,0 +1,8 @@
+package develup.submission;
+
+record CreateSubmissionRequest(
+        Long missionId,
+        String url,
+        String comment
+) {
+}

--- a/backend/src/main/java/develup/submission/CreateSubmissionRequest.java
+++ b/backend/src/main/java/develup/submission/CreateSubmissionRequest.java
@@ -9,7 +9,7 @@ record CreateSubmissionRequest(
         String comment
 ) {
 
-    public Submission toEntity(Member member, Mission mission) {
+    public Submission toSubmission(Member member, Mission mission) {
         return new Submission(url, comment, member, mission);
     }
 }

--- a/backend/src/main/java/develup/submission/Submission.java
+++ b/backend/src/main/java/develup/submission/Submission.java
@@ -59,4 +59,12 @@ public class Submission {
     public Mission getMission() {
         return mission;
     }
+
+    public Long getMemberId() {
+        return member.getId();
+    }
+
+    public Long getMissionId() {
+        return mission.getId();
+    }
 }

--- a/backend/src/main/java/develup/submission/Submission.java
+++ b/backend/src/main/java/develup/submission/Submission.java
@@ -32,4 +32,31 @@ public class Submission {
 
     protected Submission() {
     }
+
+    public Submission(String url, String comment, Member member, Mission mission) {
+        this.url = url;
+        this.comment = comment;
+        this.member = member;
+        this.mission = mission;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public Mission getMission() {
+        return mission;
+    }
 }

--- a/backend/src/main/java/develup/submission/SubmissionApi.java
+++ b/backend/src/main/java/develup/submission/SubmissionApi.java
@@ -21,6 +21,7 @@ class SubmissionApi {
     public ResponseEntity<ApiResponse<SubmissionResponse>> postSubmission(@RequestBody CreateSubmissionRequest request) {
         Member member = new Member(1L);
         SubmissionResponse response = submissionService.submit(member, request);
+
         return ResponseEntity.created(URI.create("/submissions/" + response.id()))
                 .body(new ApiResponse<>(response));
     }

--- a/backend/src/main/java/develup/submission/SubmissionApi.java
+++ b/backend/src/main/java/develup/submission/SubmissionApi.java
@@ -1,0 +1,27 @@
+package develup.submission;
+
+import java.net.URI;
+import develup.member.Member;
+import develup.support.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+class SubmissionApi {
+
+    private final SubmissionService submissionService;
+
+    public SubmissionApi(SubmissionService submissionService) {
+        this.submissionService = submissionService;
+    }
+
+    @PostMapping("/submissions")
+    public ResponseEntity<ApiResponse<SubmissionResponse>> postSubmission(@RequestBody CreateSubmissionRequest request) {
+        Member member = new Member(1L);
+        SubmissionResponse newSubmission = submissionService.submit(member, request);
+        return ResponseEntity.created(URI.create("/submissions/" + newSubmission.id()))
+                .body(new ApiResponse<>(newSubmission));
+    }
+}

--- a/backend/src/main/java/develup/submission/SubmissionApi.java
+++ b/backend/src/main/java/develup/submission/SubmissionApi.java
@@ -20,8 +20,8 @@ class SubmissionApi {
     @PostMapping("/submissions")
     public ResponseEntity<ApiResponse<SubmissionResponse>> postSubmission(@RequestBody CreateSubmissionRequest request) {
         Member member = new Member(1L);
-        SubmissionResponse newSubmission = submissionService.submit(member, request);
-        return ResponseEntity.created(URI.create("/submissions/" + newSubmission.id()))
-                .body(new ApiResponse<>(newSubmission));
+        SubmissionResponse response = submissionService.submit(member, request);
+        return ResponseEntity.created(URI.create("/submissions/" + response.id()))
+                .body(new ApiResponse<>(response));
     }
 }

--- a/backend/src/main/java/develup/submission/SubmissionRepository.java
+++ b/backend/src/main/java/develup/submission/SubmissionRepository.java
@@ -1,0 +1,6 @@
+package develup.submission;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+interface SubmissionRepository extends JpaRepository<Submission, Long> {
+}

--- a/backend/src/main/java/develup/submission/SubmissionResponse.java
+++ b/backend/src/main/java/develup/submission/SubmissionResponse.java
@@ -8,7 +8,7 @@ public record SubmissionResponse(
         String comment
 ) {
 
-    public static SubmissionResponse of(Submission submission) {
+    public static SubmissionResponse from(Submission submission) {
         return new SubmissionResponse(
                 submission.getId(),
                 submission.getMember().getId(),

--- a/backend/src/main/java/develup/submission/SubmissionResponse.java
+++ b/backend/src/main/java/develup/submission/SubmissionResponse.java
@@ -1,0 +1,20 @@
+package develup.submission;
+
+public record SubmissionResponse(
+        Long id,
+        Long memberId,
+        Long missionId,
+        String url,
+        String comment
+) {
+
+    public static SubmissionResponse of(Submission submission) {
+        return new SubmissionResponse(
+                submission.getId(),
+                submission.getMember().getId(),
+                submission.getMission().getId(),
+                submission.getUrl(),
+                submission.getComment()
+        );
+    }
+}

--- a/backend/src/main/java/develup/submission/SubmissionResponse.java
+++ b/backend/src/main/java/develup/submission/SubmissionResponse.java
@@ -11,8 +11,8 @@ public record SubmissionResponse(
     public static SubmissionResponse from(Submission submission) {
         return new SubmissionResponse(
                 submission.getId(),
-                submission.getMember().getId(),
-                submission.getMission().getId(),
+                submission.getMemberId(),
+                submission.getMissionId(),
                 submission.getUrl(),
                 submission.getComment()
         );

--- a/backend/src/main/java/develup/submission/SubmissionService.java
+++ b/backend/src/main/java/develup/submission/SubmissionService.java
@@ -21,7 +21,7 @@ class SubmissionService {
     public SubmissionResponse submit(Member member, CreateSubmissionRequest request) {
         Mission mission = missionRepository.findById(request.missionId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 미션입니다."));
-        Submission newSubmission = submissionRepository.save(request.toEntity(member, mission));
+        Submission newSubmission = submissionRepository.save(request.toSubmission(member, mission));
         return SubmissionResponse.of(newSubmission);
     }
 }

--- a/backend/src/main/java/develup/submission/SubmissionService.java
+++ b/backend/src/main/java/develup/submission/SubmissionService.java
@@ -22,6 +22,6 @@ class SubmissionService {
         Mission mission = missionRepository.findById(request.missionId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 미션입니다."));
         Submission newSubmission = submissionRepository.save(request.toSubmission(member, mission));
-        return SubmissionResponse.of(newSubmission);
+        return SubmissionResponse.from(newSubmission);
     }
 }

--- a/backend/src/main/java/develup/submission/SubmissionService.java
+++ b/backend/src/main/java/develup/submission/SubmissionService.java
@@ -22,6 +22,7 @@ class SubmissionService {
         Mission mission = missionRepository.findById(request.missionId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 미션입니다."));
         Submission newSubmission = submissionRepository.save(request.toSubmission(member, mission));
+
         return SubmissionResponse.from(newSubmission);
     }
 }

--- a/backend/src/main/java/develup/submission/SubmissionService.java
+++ b/backend/src/main/java/develup/submission/SubmissionService.java
@@ -1,0 +1,27 @@
+package develup.submission;
+
+import develup.member.Member;
+import develup.mission.Mission;
+import develup.mission.MissionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+class SubmissionService {
+
+    private final MissionRepository missionRepository;
+    private final SubmissionRepository submissionRepository;
+
+    public SubmissionService(MissionRepository missionRepository, SubmissionRepository submissionRepository) {
+        this.missionRepository = missionRepository;
+        this.submissionRepository = submissionRepository;
+    }
+
+    public SubmissionResponse submit(Member member, CreateSubmissionRequest request) {
+        Mission mission = missionRepository.findById(request.missionId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 미션입니다."));
+        Submission newSubmission = submissionRepository.save(request.toEntity(member, mission));
+        return SubmissionResponse.of(newSubmission);
+    }
+}

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -12,3 +12,6 @@ INSERT INTO mission (title, language, description, thumbnail, url)
 VALUES ('숫자 추리 게임', 'JAVA', 'https://raw.githubusercontent.com/develup-mission/java-guessing-number/main/README.md',
         'https://private-user-images.githubusercontent.com/80797824/348618796-753cae7d-779e-4847-b1b5-31ab9ff2d1cb.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjEwNDA3NTIsIm5iZiI6MTcyMTA0MDQ1MiwicGF0aCI6Ii84MDc5NzgyNC8zNDg2MTg3OTYtNzUzY2FlN2QtNzc5ZS00ODQ3LWIxYjUtMzFhYjlmZjJkMWNiLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA3MTUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwNzE1VDEwNDczMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTE2ODM0ZjI2YWMxMGEzNGUzNDk2MjVlMTdlMWRkNjI4NjkyMWUxMTQzZDdhZjRlYjM2NTgzNjE0MTQ0YTZlZmQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.yk09dRTA7LefjF0uTyYNkCgBRJcLizoKSJ8Otq7J1Gs',
         'https://github.com/develup-mission/java-guessing-number');
+
+INSERT INTO member (id)
+VALUES (1);

--- a/backend/src/test/java/develup/submission/SubmissionServiceTest.java
+++ b/backend/src/test/java/develup/submission/SubmissionServiceTest.java
@@ -1,0 +1,44 @@
+package develup.submission;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import develup.member.Member;
+import develup.mission.Language;
+import develup.mission.Mission;
+import develup.mission.MissionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class SubmissionServiceTest {
+
+    @Autowired
+    private SubmissionService submissionService;
+
+    @Autowired
+    private SubmissionRepository submissionRepository;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @BeforeEach
+    void setUp() {
+        submissionRepository.deleteAll();
+        missionRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("미션을 제출한다.")
+    void createSubmission() {
+        Member member = new Member(1L);
+        Mission mission = missionRepository.save(new Mission("미션 1", Language.JAVA, "미션 설명", "미션 썸네일", "미션 url"));
+        CreateSubmissionRequest request = new CreateSubmissionRequest(mission.getId(), "pr url", "코멘트");
+
+        submissionService.submit(member, request);
+
+        assertThat(submissionRepository.findAll()).hasSize(1);
+    }
+}


### PR DESCRIPTION
#### 구현 요약

클라이언트로부터 미션 제출 관련 POST 요청을 받으면 DB에 관련 데이터를 저장하고 클라이언트에게 응답하는 기능을 구현했습니다.

- 추후 resolver를 통해 Member 객체 생성 예정으로 Controller에서 매개변수에 Member를 명시하지 않고 임시 데이터를 사용했습니다.
```java
    @PostMapping("/submissions")
    public ResponseEntity<ApiResponse<SubmissionResponse>> postSubmission(@RequestBody CreateSubmissionRequest request) {
        Member member = new Member(1L);
        SubmissionResponse newSubmission = submissionService.submit(member, request);
        return ResponseEntity.created(URI.create("/submissions/" + newSubmission.id()))
                .body(new ApiResponse<>(newSubmission));
    }
```

- MemberRepository 생성 전이라 테스트 코드에서 직접 Member 객체를 생성했습니다.
```java
    @Test
    @DisplayName("미션을 제출한다.")
    void createSubmission() {
        Member member = new Member(1L);
```

#### 연관 이슈

close #29

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
