### PR TITLE
Swagger 초기 설정 (issue #81)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.DS_Store
+.vscode

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     runtimeOnly "io.jsonwebtoken:jjwt-gson:${JJWT_VERSION}"
     runtimeOnly "io.jsonwebtoken:jjwt-impl:${JJWT_VERSION}"
 
+    // swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/backend/src/main/java/develup/support/SwaggerConfig.java
+++ b/backend/src/main/java/develup/support/SwaggerConfig.java
@@ -1,0 +1,26 @@
+package develup.support;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components())
+                .info(info());
+    }
+
+    private Info info() {
+        return new Info()
+                .title("데벨업 API")
+                .description("데벨업 API 명세서입니다.")
+                .version("0.0.1");
+    }
+}
+

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -16,6 +16,16 @@ spring:
     hibernate:
       ddl-auto: create
 
+springdoc:
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    path: /api-docs
+    disable-swagger-default-url: true
+    display-request-duration: true
+    operations-sorter: alpha
+    tags-sorter: alpha
+
 logging:
   level:
     org.springframework.orm.jpa: DEBUG


### PR DESCRIPTION
#### 구현 요약

두괄식 결론

- Swagger 커스텀 어노테이션 없이 초기 설정만 했습니다.
- ⚠️ 커스텀 어노테이션 설정을 위해서는 우선 커스텀 예외와 전역 예외 처리에 대해서 정하고 가야할 것 같습니다.
- 개인적으로 응답 예시, 헤더, 필요하다면 파라미터 예시 등등이 들어간다고 생각하면 api document interface를 만들고 controller가 구현하는 방식이 좋을 것 같습니다.

추가적인 내용

- 프로젝트에서 정의한 ApiResponse record와 Swagger의 ApiResponse가 겹쳐서 좀 그럼
- Swagger 접속은 "{서버주소}/api-docs" or "{서버주소}/swagger-ui.html"로 접속 가능
- 버저닝은 고민이 됩니다. 

팀원 페이먼츠 미션 참고

- [릴리 미션 설정](https://github.dev/Minjoo522/spring-roomescape-payment/tree/step2)
  - Tag와 Operation의 summary만 사용했음.
- [리브 미션 설정](https://github.dev/Minjoo522/spring-roomescape-payment/tree/step2)
  - 성공과 예외에 대한 커스텀 어노테이션이 있으나, 예외 메세지가 보여지지 않고 타입만 나옴
  - ex) { message: string }
- [로빈 미션 설정](https://github.dev/robinjoon/spring-roomescape-payment/tree/step2%2C4)
  - 성공과 예외에 대한 커스텀 어노테이션을 작성했음.
  - 성공 커스텀이 필요한지 모르겠고, header에 대한 속성도 필요할 것 같음. 추후에 추가적인 속성이 더 들어갈 가능성도 있음.
  - 예외 커스텀에 대해서 예외 상태 코드와 메세지를 enum으로 정의했기 때문에 사용할 수 있었음. 아직 커스텀 예외에 대해서 정하지 않았지만 사용한다면 좋을 것 같음.
    - ex) `@ErrorApiResponse({DUPLICATE_RESERVATION_TIME, EMPTY_TIME})`

#### 연관 이슈

close #81

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                | 설명                                                 |
| ------------------- | ---------------------------------------------------- |
| R (Request Changes) | 적극적으로 반영을 고려해주세요                       |
| C (Comment)         | 웬만하면 반영해주세요                                |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
