### PR TITLE
미션 상세 조회 시 제출했던 문제인지 확인하는 기능 구현 (issue #61)

### DIFF
--- a/backend/src/main/java/develup/mission/MissionApi.java
+++ b/backend/src/main/java/develup/mission/MissionApi.java
@@ -1,6 +1,8 @@
 package develup.mission;
 
 import java.util.List;
+import develup.member.Member;
+import develup.member.Provider;
 import develup.support.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,6 +25,11 @@ class MissionApi {
 
     @GetMapping("/missions/{id}")
     public ResponseEntity<ApiResponse<MissionResponse>> getMission(@PathVariable Long id) {
-        return ResponseEntity.ok(new ApiResponse<>(missionService.getMissionById(id)));
+        Member member = new Member(1L, "email", Provider.GITHUB, 1234L, "name", "image");
+        boolean guest = false;
+
+        MissionResponse missionResponse = missionService.getMissionById(id, member, guest);
+
+        return ResponseEntity.ok(new ApiResponse<>(missionResponse));
     }
 }

--- a/backend/src/main/java/develup/mission/MissionResponse.java
+++ b/backend/src/main/java/develup/mission/MissionResponse.java
@@ -12,10 +12,10 @@ public record MissionResponse(
 ) {
 
     public static MissionResponse from(Mission mission) {
-        return from(mission, false, null);
+        return of(mission, false, null);
     }
 
-    public static MissionResponse from(Mission mission, boolean isSubmitted, String submittedPrUrl) {
+    public static MissionResponse of(Mission mission, boolean isSubmitted, String submittedPrUrl) {
         return new MissionResponse(
                 mission.getId(),
                 mission.getTitle(),

--- a/backend/src/main/java/develup/mission/MissionResponse.java
+++ b/backend/src/main/java/develup/mission/MissionResponse.java
@@ -6,17 +6,25 @@ public record MissionResponse(
         Language language,
         String description,
         String thumbnail,
-        String url
+        String url,
+        boolean isSubmitted,
+        String submittedPrUrl
 ) {
 
     public static MissionResponse from(Mission mission) {
+        return from(mission, false, null);
+    }
+
+    public static MissionResponse from(Mission mission, boolean isSubmitted, String submittedPrUrl) {
         return new MissionResponse(
                 mission.getId(),
                 mission.getTitle(),
                 mission.getLanguage(),
                 mission.getDescription(),
                 mission.getThumbnail(),
-                mission.getUrl()
+                mission.getUrl(),
+                isSubmitted,
+                submittedPrUrl
         );
     }
 }

--- a/backend/src/main/java/develup/mission/MissionService.java
+++ b/backend/src/main/java/develup/mission/MissionService.java
@@ -1,15 +1,19 @@
 package develup.mission;
 
 import java.util.List;
+import develup.member.Member;
+import develup.submission.SubmissionRepository;
 import org.springframework.stereotype.Service;
 
 @Service
 class MissionService {
 
     private final MissionRepository missionRepository;
+    private final SubmissionRepository submissionRepository;
 
-    public MissionService(MissionRepository missionRepository) {
+    public MissionService(MissionRepository missionRepository, SubmissionRepository submissionRepository) {
         this.missionRepository = missionRepository;
+        this.submissionRepository = submissionRepository;
     }
 
     public List<MissionResponse> getMissions() {
@@ -19,9 +23,16 @@ class MissionService {
                 .toList();
     }
 
-    public MissionResponse getMissionById(Long id) {
-        return missionRepository.findById(id)
-                .map(MissionResponse::from)
+    public MissionResponse getMissionById(Long missionId, Member member, boolean guest) {
+        Mission mission = missionRepository.findById(missionId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 미션입니다."));
+
+        if (guest) {
+            return MissionResponse.from(mission);
+        }
+
+        return submissionRepository.findFirstByMember_IdAndMission_IdOrderByIdDesc(member.getId(), missionId)
+                .map(submission -> MissionResponse.from(mission, true, submission.getUrl()))
+                .orElseGet(() -> MissionResponse.from(mission));
     }
 }

--- a/backend/src/main/java/develup/mission/MissionService.java
+++ b/backend/src/main/java/develup/mission/MissionService.java
@@ -32,7 +32,7 @@ class MissionService {
         }
 
         return submissionRepository.findFirstByMember_IdAndMission_IdOrderByIdDesc(member.getId(), missionId)
-                .map(submission -> MissionResponse.from(mission, true, submission.getUrl()))
+                .map(submission -> MissionResponse.of(mission, true, submission.getUrl()))
                 .orElseGet(() -> MissionResponse.from(mission));
     }
 }

--- a/backend/src/main/java/develup/submission/SubmissionRepository.java
+++ b/backend/src/main/java/develup/submission/SubmissionRepository.java
@@ -26,4 +26,6 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     List<Submission> findNonMatchedSubmissions(Mission mission);
 
     Optional<Submission> findFirstByMember_IdOrderByIdDesc(Long id);
+
+    Optional<Submission> findFirstByMember_IdAndMission_IdOrderByIdDesc(Long memberId, Long missionId);
 }

--- a/backend/src/test/java/develup/mission/MissionServiceTest.java
+++ b/backend/src/test/java/develup/mission/MissionServiceTest.java
@@ -73,7 +73,7 @@ class MissionServiceTest {
 
         MissionResponse response = missionService.getMissionById(mission.getId(), member, false);
 
-        assertThat(response).isEqualTo(MissionResponse.from(mission, true, submittedPrUrl));
+        assertThat(response).isEqualTo(MissionResponse.of(mission, true, submittedPrUrl));
     }
 
     @Test

--- a/backend/src/test/java/develup/mission/MissionServiceTest.java
+++ b/backend/src/test/java/develup/mission/MissionServiceTest.java
@@ -4,6 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import develup.member.Member;
+import develup.member.MemberRepository;
+import develup.member.Provider;
+import develup.submission.Submission;
+import develup.submission.SubmissionRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +25,11 @@ class MissionServiceTest {
     @Autowired
     private MissionRepository missionRepository;
 
+    @Autowired
+    private SubmissionRepository submissionRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
     @Test
     @DisplayName("모든 미션을 조회한다.")
     void getMissions() {
@@ -32,19 +42,51 @@ class MissionServiceTest {
     }
 
     @Test
-    @DisplayName("미션 식별자로 미션 단건을 조회한다.")
-    void getMissionById() {
+    @DisplayName("로그인하지 않은 사용자가 미션 식별자로 미션 단건을 조회한다.")
+    void getMissionByIdWhenGuest() {
         Mission mission = missionRepository.save(new Mission("미션 1", Language.JAVA, "미션 설명", "미션 썸네일", "미션 url"));
+        Member member = createMember(-1L);
 
-        MissionResponse response = missionService.getMissionById(mission.getId());
+        MissionResponse response = missionService.getMissionById(mission.getId(), member, true);
 
         assertThat(response).isEqualTo(MissionResponse.from(mission));
     }
 
     @Test
+    @DisplayName("로그인한 멤버가 제출하지 않은 미션을 미션 식별자로 미션 단건을 조회한다.")
+    void getMissionByIdWhenNotSubmitted() {
+        Mission mission = missionRepository.save(new Mission("미션 1", Language.JAVA, "미션 설명", "미션 썸네일", "미션 url"));
+        Member member = memberRepository.save(createMember(1L));
+
+        MissionResponse response = missionService.getMissionById(mission.getId(), member, false);
+
+        assertThat(response).isEqualTo(MissionResponse.from(mission));
+    }
+
+    @Test
+    @DisplayName("로그인한 멤버가 제출한 미션을 미션 식별자로 미션 단건을 조회한다.")
+    void getMissionByIdWhenSubmitted() {
+        Mission mission = missionRepository.save(new Mission("미션 1", Language.JAVA, "미션 설명", "미션 썸네일", "미션 url"));
+        Member member = memberRepository.save(createMember(1L));
+        String submittedPrUrl = "https://gitbub.com/example/pr";
+        submissionRepository.save(new Submission(submittedPrUrl, "comment", member, mission));
+
+        MissionResponse response = missionService.getMissionById(mission.getId(), member, false);
+
+        assertThat(response).isEqualTo(MissionResponse.from(mission, true, submittedPrUrl));
+    }
+
+    @Test
     @DisplayName("존재하지 않는 미션 식별자로 미션 조회시 예외가 발생한다.")
     void getMissionByUndefinedId() {
-        assertThatThrownBy(() -> missionService.getMissionById(-1L))
-                .isInstanceOf(IllegalArgumentException.class);
+        Member member = createMember(-1L);
+
+        assertThatThrownBy(() -> missionService.getMissionById(-1L, member, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("존재하지 않는 미션입니다.");
+    }
+
+    private Member createMember(Long id) {
+        return new Member(id, "email", Provider.GITHUB, 1234L, "name", "image");
     }
 }

--- a/backend/src/test/java/develup/submission/SubmissionRepositoryTest.java
+++ b/backend/src/test/java/develup/submission/SubmissionRepositoryTest.java
@@ -3,6 +3,7 @@ package develup.submission;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import java.util.Optional;
 import develup.member.Member;
 import develup.member.MemberRepository;
 import develup.member.Provider;
@@ -31,15 +32,31 @@ class SubmissionRepositoryTest {
     @Test
     @DisplayName("아직 매칭되지 않은 제출을 불러온다.")
     void findNonMatchedSubmission() {
+        Member member = createMember();
         Mission mission = createMission();
-        Submission submission1 = createSubmission(mission);
-        Submission submission2 = createSubmission(mission);
+        Submission submission1 = createSubmission(mission, member);
+        Submission submission2 = createSubmission(mission, member);
 
         List<Submission> result = submissionRepository.findNonMatchedSubmissions(mission);
 
         assertThat(result)
                 .extracting(Submission::getId)
                 .contains(submission1.getId(), submission2.getId());
+    }
+
+    @Test
+    @DisplayName("멤버 식별자와 미션 식별자로 제일 최근 제출을 불러온다.")
+    void findFirstByMember_IdOrderByIdDesc() {
+        Member member = createMember();
+        Mission mission = createMission();
+        createSubmission(mission, member);
+        Submission lateSubmission = createSubmission(mission, member);
+
+        Optional<Submission> result = submissionRepository
+                .findFirstByMember_IdAndMission_IdOrderByIdDesc(member.getId(), mission.getId());
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getId()).isEqualTo(lateSubmission.getId());
     }
 
     private Mission createMission() {
@@ -55,9 +72,7 @@ class SubmissionRepositoryTest {
         return mission;
     }
 
-    private Submission createSubmission(Mission mission) {
-        Member member = createMember();
-
+    private Submission createSubmission(Mission mission, Member member) {
         Submission submission = new Submission(
                 "sample",
                 "comment",


### PR DESCRIPTION
#### 구현 요약

> ⚠️ 우선순위 2에 위치한 기능입니다.
> 중요하지 않으니 시간나시면 리뷰해주세요!

우선 리뷰를 받고 수정 후 API 명세서를 작성하겠습니다.

현재 만들어져있는 미션 단건 조회 기능에서 로그인한 사용자가 제출한 미션을 조회하는 경우 제출한 PR을 보여주는 링크를 넣어야 합니다.
⚠️ 현재 응답에서 isSubmitted(boolean)과 submittedPrUrl(String)을 추가했습니다. 두 필드가 겹치는 느낌이 있지만 사용의 편의를 위해 둘 다 넣었습니다.

이 조회 기능을 사용하는 경우 다음과 같습니다.

1. 비로그인한 게스트가 미션을 조회
2. 로그인한 사용자가 제출하지 않은 미션을 조회,
3. 로그인한 사용자가 제출한 미션을 조회

1번과 2번의 경우 isSubmitted는 false이고 submittedPrUrl은 null입니다.
3번의 경우 isSubmitted는 true이고 submittedPrUrl은 PR 링크입니다.

⚠️ 한 미션에 대해서 여러 PR을 제출할 수 있는걸로 알고 있습니다.  
그래서 제일 최근에 제출한 PR을 보여주는 것으로 했습니다.
ex) findFirstByMember_IdAndMission_IdOrderByIdDesc(memberId, missionId)

⚠️ 여기서 또 한가지 의문이 생겼습니다.
프론트 페이지에서 매칭 대기거나 리뷰 진행 중이면 다시 참여하기 버튼을 보여주는게 맞을까요??

<img width="411" alt="image" src="https://github.com/user-attachments/assets/d0010f86-1953-403d-bd91-bc0ac3f4454c">

#### 연관 이슈

close #61

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                | 설명                                                 |
| ------------------- | ---------------------------------------------------- |
| R (Request Changes) | 적극적으로 반영을 고려해주세요                       |
| C (Comment)         | 웬만하면 반영해주세요                                |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
