### PR TITLE
커밋 메시지 상단 한 줄만 사용하도록 수정 (issue #142)

### DIFF
--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -73,6 +73,11 @@ jobs:
       - deploy
     if: success()
     steps:
+      - name: Extract Commit Title
+        run: |
+          COMMIT_TITLE=$(echo "${{ github.event.head_commit.message }}" | head -n 1)
+          echo "COMMIT_TITLE=$COMMIT_TITLE" >> $GITHUB_ENV   
+
       - name: Build and Deploy Success
         uses: slackapi/slack-github-action@v1.24.0
         with:
@@ -85,7 +90,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "<!channel> \n 📣 Server Build & Deploy 결과를 안내 드립니다. 📣 \n\t • 🚀 Build Success \n\t • 🟢 Deploy Success \n\t • 🏷️ 관련 Commit: <${{ github.event.head_commit.url }}|${{ github.event.head_commit.message }}>"
+                    "text": "<!channel> \n 📣 Server Build & Deploy 결과를 안내 드립니다. 📣 \n\t • 🚀 Build Success \n\t • 🟢 Deploy Success \n\t • 🏷️ 관련 Commit: <${{ github.event.head_commit.url }}|${{ env.COMMIT_TITLE }}>"
                   }
                 }
               ]
@@ -99,6 +104,11 @@ jobs:
       - build
     if: failure()
     steps:
+      - name: Extract Commit Title
+        run: |
+          COMMIT_TITLE=$(echo "${{ github.event.head_commit.message }}" | head -n 1)
+          echo "COMMIT_TITLE=$COMMIT_TITLE" >> $GITHUB_ENV   
+
       - name: Build Fail
         uses: slackapi/slack-github-action@v1.24.0
         with:
@@ -111,7 +121,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "<!channel> \n 📣 Server Build & Deploy 결과를 안내 드립니다. 📣 \n\t • 🔴 Build Fail \n\t • 🏷️ 관련 Commit: <${{ github.event.head_commit.url }}|${{ github.event.head_commit.message }}>"
+                    "text": "<!channel> \n 📣 Server Build & Deploy 결과를 안내 드립니다. 📣 \n\t • 🔴 Build Fail \n\t • 🏷️ 관련 Commit: <${{ github.event.head_commit.url }}|${{ env.COMMIT_TITLE }}>"
                   }
                 }
               ]
@@ -125,6 +135,11 @@ jobs:
       - deploy
     if: failure()
     steps:
+      - name: Extract Commit Title
+        run: |
+          COMMIT_TITLE=$(echo "${{ github.event.head_commit.message }}" | head -n 1)
+          echo "COMMIT_TITLE=$COMMIT_TITLE" >> $GITHUB_ENV   
+
       - name: Deploy Fail
         uses: slackapi/slack-github-action@v1.24.0
         with:
@@ -137,7 +152,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "<!channel> \n 📣 Server Build & Deploy 결과를 안내 드립니다. 📣 \n\t • 🚀Build Success \n\t • 🔴Deploy Fail \n\t • 🏷️ 관련 Commit: <${{ github.event.head_commit.url }}|${{ github.event.head_commit.message }}>"
+                    "text": "<!channel> \n 📣 Server Build & Deploy 결과를 안내 드립니다. 📣 \n\t • 🚀Build Success \n\t • 🔴Deploy Fail \n\t • 🏷️ 관련 Commit: <${{ github.event.head_commit.url }}|${{ env.COMMIT_TITLE }}>"
                   }
                 }
               ]


### PR DESCRIPTION
#### 구현 요약

커밋 메시지가 긴 경우 JSON 형식이 깨져서 슬랙 메시지 전달이 되지 않는 오류가 있었습니다.
슬랙 메시지 전달 각 job의 첫 step으로 커밋 타이틀만 깃허브 env로 등록하는 기능을 추가했습니다.

#### 연관 이슈

close #142

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
