### PR TITLE
@WebMvcTest로 전환(issue #270)

### DIFF
--- a/backend/src/test/java/develup/api/ApiTestSupport.java
+++ b/backend/src/test/java/develup/api/ApiTestSupport.java
@@ -1,0 +1,42 @@
+package develup.api;
+
+import develup.api.auth.AuthArgumentResolver;
+import develup.api.auth.CookieAuthorizationExtractor;
+import develup.application.auth.AuthService;
+import develup.application.member.MemberService;
+import develup.application.mission.MissionService;
+import develup.application.solution.SolutionService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = {
+        AuthApi.class,
+        MemberApi.class,
+        MissionApi.class,
+        SolutionApi.class
+})
+public class ApiTestSupport {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @MockBean
+    protected AuthService authService;
+
+    @MockBean
+    protected MemberService memberService;
+
+    @MockBean
+    protected MissionService missionService;
+
+    @MockBean
+    protected SolutionService solutionService;
+
+    @MockBean
+    protected CookieAuthorizationExtractor cookieAuthorizationExtractor;
+
+    @MockBean
+    protected AuthArgumentResolver argumentResolver;
+}

--- a/backend/src/test/java/develup/api/ApiTestSupport.java
+++ b/backend/src/test/java/develup/api/ApiTestSupport.java
@@ -11,12 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = {
-        AuthApi.class,
-        MemberApi.class,
-        MissionApi.class,
-        SolutionApi.class
-})
+@WebMvcTest
 public class ApiTestSupport {
 
     @Autowired

--- a/backend/src/test/java/develup/api/AuthApiTest.java
+++ b/backend/src/test/java/develup/api/AuthApiTest.java
@@ -7,18 +7,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import develup.application.auth.AuthService;
-import develup.support.IntegrationTestSupport;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
-class AuthApiTest extends IntegrationTestSupport {
-
-    @MockBean
-    private AuthService authService;
+class AuthApiTest extends ApiTestSupport {
 
     @Test
     @DisplayName("github 로그인 페이지로 리다이렉트한다.")

--- a/backend/src/test/java/develup/api/MemberApiTest.java
+++ b/backend/src/test/java/develup/api/MemberApiTest.java
@@ -2,29 +2,17 @@ package develup.api;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import develup.application.member.MemberResponse;
-import develup.application.member.MemberService;
-import develup.infra.auth.JwtTokenProvider;
-import develup.support.IntegrationTestSupport;
-import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
-class MemberApiTest extends IntegrationTestSupport {
-
-    @MockBean
-    private JwtTokenProvider jwtTokenProvider;
-
-    @MockBean
-    private MemberService memberService;
+class MemberApiTest extends ApiTestSupport {
 
     @Test
     @DisplayName("내 정보를 조회한다.")
@@ -35,15 +23,10 @@ class MemberApiTest extends IntegrationTestSupport {
                 "example",
                 "https://example.com/image.png"
         );
-        BDDMockito.given(jwtTokenProvider.getMemberId(any()))
-                .willReturn(1L);
-        BDDMockito.given(memberService.getMemberById(anyLong()))
+        BDDMockito.given(memberService.getMemberById(any()))
                 .willReturn(response);
 
-        mockMvc.perform(
-                        get("/members/mine")
-                                .cookie(new Cookie("token", "mock_token"))
-                )
+        mockMvc.perform(get("/members/mine"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id", equalTo(1)))

--- a/backend/src/test/java/develup/api/MissionApiTest.java
+++ b/backend/src/test/java/develup/api/MissionApiTest.java
@@ -11,20 +11,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 import develup.application.mission.MissionResponse;
-import develup.application.mission.MissionService;
 import develup.application.mission.MissionWithStartedResponse;
 import develup.domain.mission.Mission;
-import develup.support.IntegrationTestSupport;
 import develup.support.data.MissionTestData;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
-import org.springframework.boot.test.mock.mockito.MockBean;
 
-class MissionApiTest extends IntegrationTestSupport {
-
-    @MockBean
-    private MissionService missionService;
+class MissionApiTest extends ApiTestSupport {
 
     @Test
     @DisplayName("미션 목록을 조회한다.")

--- a/backend/src/test/java/develup/api/SolutionApiTest.java
+++ b/backend/src/test/java/develup/api/SolutionApiTest.java
@@ -11,15 +11,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import develup.api.auth.AuthArgumentResolver;
 import develup.application.auth.Accessor;
 import develup.application.solution.SolutionRequest;
 import develup.application.solution.SolutionResponse;
-import develup.application.solution.SolutionService;
 import develup.domain.solution.Solution;
-import develup.domain.solution.SolutionRepository;
 import develup.domain.solution.SolutionSummary;
-import develup.support.IntegrationTestSupport;
 import develup.support.data.MemberTestData;
 import develup.support.data.MissionTestData;
 import develup.support.data.SolutionTestData;
@@ -27,22 +23,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
-class SolutionApiTest extends IntegrationTestSupport {
+class SolutionApiTest extends ApiTestSupport {
 
     @Autowired
     private ObjectMapper objectMapper;
-
-    @MockBean
-    private SolutionRepository solutionRepository;
-
-    @MockBean
-    private SolutionService solutionService;
-
-    @MockBean
-    private AuthArgumentResolver argumentResolver;
 
     @Test
     @DisplayName("솔루션 목록을 조회한다.")
@@ -115,7 +101,7 @@ class SolutionApiTest extends IntegrationTestSupport {
 
         mockMvc.perform(post("/solutions/submit")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(new ObjectMapper().writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(request)))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.id", equalTo(1)))
@@ -141,12 +127,8 @@ class SolutionApiTest extends IntegrationTestSupport {
                 .withId(1L)
                 .build();
         SolutionResponse solutionResponse = SolutionResponse.start(solution);
-
-        BDDMockito.given(argumentResolver.resolveArgument(any(), any(), any(), any()))
-                .willReturn(new Accessor(1L));
         BDDMockito.given(solutionService.startMission(any(), any()))
                 .willReturn(solutionResponse);
-
         StartSolutionRequest request = new StartSolutionRequest(1L);
 
         mockMvc.perform(

--- a/backend/src/test/java/develup/api/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/develup/api/exception/GlobalExceptionHandlerTest.java
@@ -47,7 +47,7 @@ class GlobalExceptionHandlerTest {
     ObjectMapper objectMapper;
 
     @Test
-    @DisplayName("DTO를 검증 예외를 처리한다.")
+    @DisplayName("DTO 검증 예외를 처리한다.")
     void methodArgumentNotValidException() throws Exception {
         mockMvc.perform(
                         post("/")


### PR DESCRIPTION
#### 구현 요약

기존 api 테스트를 @WebMvcTest로 전환했어요.
전환 맥락을 말씀 드려요. 기존 api 테스트는 두 가지로 나눠서 테스트하기로 결정한 맥락이 있어요.

-  전구간 통합 테스트 :  가독성이 좋은 RestAssured를 사용하고, `@SprintBootTest`를 이용해 실제 환경과 유사하게 테스트한다.
-  API 슬라이스 테스트 : 표현 계층에 대한 status, handler mapping, message converting을 테스트한다.

IntegrationTestSupport의 경우에는 `@SpringBootTest`를 이용하며, application, infra 테스트를 수행할 때 사용되어야합니다.
다만, 현재는 api 테스트 할때 IntegrationTestSupport를 상속받고 `@MockBean`을 사용하기 때문에 컨텍스트 캐싱이 어렵습니다. 
또한, 과거 결정사항과 무관한 방식으로 나아가고 있다고 생각했어요. 

따라서, API 슬라이스 테스트를 하기 위해서 ApiTestSupport를 신규로 생성하고 api 테스트에서 상속받도록 변경했어요.
컨텍스트는 현재 6개에서 3개로 줄였어요. 설명이 더 필요한 부분이 있다면, 커멘트 부탁 드립니다.

- exception handler 테스트용 컨텍스트
- api 슬라이스 테스트용 컨텍스트
- application, infra 테스트용 컨텍스트


#### 연관 이슈

- close #270 

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
