### PR TITLE
미션에 짧은 한줄 소개가 없는 오류 수정 (Issue #274)

### DIFF
--- a/backend/src/main/java/develup/application/mission/MissionResponse.java
+++ b/backend/src/main/java/develup/application/mission/MissionResponse.java
@@ -7,6 +7,7 @@ public record MissionResponse(
         String title,
         String descriptionUrl,
         String thumbnail,
+        String summary,
         String url
 ) {
 
@@ -16,6 +17,7 @@ public record MissionResponse(
                 mission.getTitle(),
                 mission.getDescriptionUrl(),
                 mission.getThumbnail(),
+                mission.getSummary(),
                 mission.getUrl()
         );
     }

--- a/backend/src/main/java/develup/application/mission/MissionResponse.java
+++ b/backend/src/main/java/develup/application/mission/MissionResponse.java
@@ -5,7 +5,6 @@ import develup.domain.mission.Mission;
 public record MissionResponse(
         Long id,
         String title,
-        String descriptionUrl,
         String thumbnail,
         String summary,
         String url
@@ -15,7 +14,6 @@ public record MissionResponse(
         return new MissionResponse(
                 mission.getId(),
                 mission.getTitle(),
-                mission.getDescriptionUrl(),
                 mission.getThumbnail(),
                 mission.getSummary(),
                 mission.getUrl()

--- a/backend/src/main/java/develup/domain/mission/Mission.java
+++ b/backend/src/main/java/develup/domain/mission/Mission.java
@@ -23,19 +23,23 @@ public class Mission {
     private String thumbnail;
 
     @Column(nullable = false)
+    private String summary;
+
+    @Column(nullable = false)
     private String url;
 
     protected Mission() {
     }
 
-    public Mission(String title, String thumbnail, String url) {
-        this(null, title, thumbnail, url);
+    public Mission(String title, String thumbnail, String summary, String url) {
+        this(null, title, thumbnail, summary, url);
     }
 
-    public Mission(Long id, String title, String thumbnail, String url) {
+    public Mission(Long id, String title, String thumbnail, String summary, String url) {
         this.id = id;
         this.title = title;
         this.thumbnail = thumbnail;
+        this.summary = summary;
         this.url = url;
     }
 
@@ -49,6 +53,10 @@ public class Mission {
 
     public String getThumbnail() {
         return thumbnail;
+    }
+
+    public String getSummary() {
+        return summary;
     }
 
     public String getUrl() {

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -7,10 +7,10 @@ VALUES ('test1@gmail.com', 'GITHUB', '1234', '리브', 'www.naver.com');
 INSERT INTO member (email, provider, social_id, name, image_url)
 VALUES ('test1@gmail.com', 'GITHUB', '1234', '아톰', 'www.naver.com');
 
-INSERT INTO mission (title, thumbnail, url)
-VALUES ('루터회관 흡연 단속', 'https://raw.githubusercontent.com/develup-mission/docs/b8c5d4d0e77de4473c78a44732c4746687583b08/image/java-smoking.png', 'https://github.com/develup-mission/java-smoking');
-INSERT INTO mission (title, thumbnail, url)
-VALUES ('java-guessing-number', 'https://raw.githubusercontent.com/develup-mission/docs/main/image/java-smoking.png','https://github.com/develup-mission/java-guessing-number');
+INSERT INTO mission (title, thumbnail, summary, url)
+VALUES ('루터회관 흡연 단속', 'https://github.com/develup-mission/docs/blob/main/image/java-smoking.png', '담배피다 걸린 행성이를 위한 벌금 계산 미션', 'https://github.com/develup-mission/java-smoking');
+INSERT INTO mission (title, thumbnail, summary, url)
+VALUES ('java-guessing-number', 'https://github.com/develup-mission/docs/blob/main/image/java-guessing-number.png', '숫자를 맞춰보자', 'https://github.com/develup-mission/java-guessing-number');
 
 INSERT INTO solution (mission_id, member_id, title, description, url, status) VALUES (1, 1, '릴리 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED');
 INSERT INTO solution (mission_id, member_id, title, description, url, status) VALUES (1, 2, '아톰 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED');

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -8,9 +8,9 @@ INSERT INTO member (email, provider, social_id, name, image_url)
 VALUES ('test1@gmail.com', 'GITHUB', '1234', '아톰', 'www.naver.com');
 
 INSERT INTO mission (title, thumbnail, summary, url)
-VALUES ('루터회관 흡연 단속', 'https://github.com/develup-mission/docs/blob/main/image/java-smoking.png', '담배피다 걸린 행성이를 위한 벌금 계산 미션', 'https://github.com/develup-mission/java-smoking');
+VALUES ('루터회관 흡연 단속', 'https://raw.githubusercontent.com/develup-mission/docs/main/image/java-smoking.png', '담배피다 걸린 행성이를 위한 벌금 계산 미션', 'https://github.com/develup-mission/java-smoking');
 INSERT INTO mission (title, thumbnail, summary, url)
-VALUES ('java-guessing-number', 'https://github.com/develup-mission/docs/blob/main/image/java-guessing-number.png', '숫자를 맞춰보자', 'https://github.com/develup-mission/java-guessing-number');
+VALUES ('java-guessing-number', 'https://raw.githubusercontent.com/develup-mission/docs/main/image/java-guessing-number.png', '숫자를 맞춰보자', 'https://github.com/develup-mission/java-guessing-number');
 
 INSERT INTO solution (mission_id, member_id, title, description, url, status) VALUES (1, 1, '릴리 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED');
 INSERT INTO solution (mission_id, member_id, title, description, url, status) VALUES (1, 2, '아톰 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED');

--- a/backend/src/test/java/develup/api/MissionApiTest.java
+++ b/backend/src/test/java/develup/api/MissionApiTest.java
@@ -36,13 +36,9 @@ class MissionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data[0].title", equalTo("루터회관 흡연단속")))
                 .andExpect(jsonPath("$.data[0].thumbnail", equalTo("https://thumbnail.com/1.png")))
                 .andExpect(jsonPath("$.data[0].url", equalTo("https://github.com/develup/mission")))
-                .andExpect(jsonPath("$.data[0].descriptionUrl",
-                        equalTo("https://raw.githubusercontent.com/develup-mission/mission/main/README.md")))
                 .andExpect(jsonPath("$.data[1].title", equalTo("루터회관 흡연단속")))
                 .andExpect(jsonPath("$.data[1].thumbnail", equalTo("https://thumbnail.com/1.png")))
                 .andExpect(jsonPath("$.data[1].url", equalTo("https://github.com/develup/mission")))
-                .andExpect(jsonPath("$.data[1].descriptionUrl",
-                        equalTo("https://raw.githubusercontent.com/develup-mission/mission/main/README.md")))
                 .andExpect(jsonPath("$.data.length()", is(2)));
     }
 

--- a/backend/src/test/java/develup/support/data/MissionTestData.java
+++ b/backend/src/test/java/develup/support/data/MissionTestData.java
@@ -8,6 +8,7 @@ public class MissionTestData {
         return new MissionBuilder()
                 .withTitle("루터회관 흡연단속")
                 .withThumbnail("https://thumbnail.com/1.png")
+                .withSummary("담배피다 걸린 행성이를 위한 벌금 계산 미션")
                 .withUrl("https://github.com/develup/mission");
     }
 
@@ -16,6 +17,7 @@ public class MissionTestData {
         private Long id;
         private String title;
         private String thumbnail;
+        private String summary;
         private String url;
 
         public MissionBuilder withId(Long id) {
@@ -33,6 +35,11 @@ public class MissionTestData {
             return this;
         }
 
+        public MissionBuilder withSummary(String summary) {
+            this.summary = summary;
+            return this;
+        }
+
         public MissionBuilder withUrl(String url) {
             this.url = url;
             return this;
@@ -43,6 +50,7 @@ public class MissionTestData {
                     id,
                     title,
                     thumbnail,
+                    summary,
                     url
             );
         }


### PR DESCRIPTION
#### 구현 요약

- Mission 에 summary 필드 추가
- MissionResponse( 미션 목록에서 사용하는 응답 객체)에 descriptionUrl 제거 및 summary 추가
- 이에 따른 테스트 및 기초 데이터 수정

미션 목록 응답에 descriptionUrl이 필요 없다고 생각해서 제거하고, 짧은 미션 설명인 summary를 추가했습니다!

#### 연관 이슈

- close #274

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
