### PR TITLE
미션 상세 페이지 하드코딩된 내용을 실제 데이터로 대체 (issue: #240)

### DIFF
--- a/frontend/src/apis/missionAPI.ts
+++ b/frontend/src/apis/missionAPI.ts
@@ -1,6 +1,13 @@
 import { develupAPIClient } from './clients/develupClient';
 import { PATH } from './paths';
-import type { Mission, MissionSubmission, SubmissionPayload, Submission } from '@/types';
+import type {
+  Mission,
+  MissionSubmission,
+  SubmissionPayload,
+  Submission,
+  MissionResponse,
+} from '@/types';
+import { populateMissionDescription } from './utils/populateMissionDescription';
 
 interface getMissionInProgressResponse {
   data: MissionSubmission;
@@ -11,14 +18,14 @@ interface getMissionCompletedResponse {
 }
 
 interface getMissionByIdResponse {
-  data: Mission;
+  data: MissionResponse;
 }
 
 interface getAllMissionResponse {
-  data: Mission[];
+  data: MissionResponse[];
 }
 
-export const getAllMissions = async (): Promise<Mission[]> => {
+export const getAllMissions = async (): Promise<MissionResponse[]> => {
   const { data } = await develupAPIClient.get<getAllMissionResponse>(PATH.missionList);
 
   return data;
@@ -26,8 +33,9 @@ export const getAllMissions = async (): Promise<Mission[]> => {
 
 export const getMissionById = async (id: number): Promise<Mission> => {
   const { data } = await develupAPIClient.get<getMissionByIdResponse>(`${PATH.missionList}/${id}`);
+  const mission = await populateMissionDescription(data);
 
-  return data;
+  return mission;
 };
 
 export const getMissionInProgress = async (): Promise<MissionSubmission> => {

--- a/frontend/src/apis/utils/populateMissionDescription.ts
+++ b/frontend/src/apis/utils/populateMissionDescription.ts
@@ -1,0 +1,28 @@
+import type { MissionResponse } from '@/types';
+import * as Sentry from '@sentry/react';
+
+export const populateMissionDescription = async (missionResponse: MissionResponse) => {
+  try {
+    const response = await fetch(missionResponse.descriptionUrl);
+
+    if (!response.ok) {
+      throw new Error(response.statusText);
+    }
+
+    const description = await response.text();
+
+    const mission = {
+      ...missionResponse,
+      description,
+    };
+
+    return mission;
+  } catch (err) {
+    Sentry.withScope((scope: Sentry.Scope) => {
+      scope.setLevel('error');
+      scope.setTag('url', window.location.href);
+      Sentry.captureException(err);
+    });
+    throw err;
+  }
+};

--- a/frontend/src/components/MissionDetail/MissionDetailContent.tsx
+++ b/frontend/src/components/MissionDetail/MissionDetailContent.tsx
@@ -1,96 +1,14 @@
 import * as S from './MissionDetail.styled';
 
 interface MissionDetailContentProps {
-  descriptionUrl: string;
+  description: string;
 }
 
-export default function MissionDetailContent({ descriptionUrl }: MissionDetailContentProps) {
-  descriptionUrl; // 추후 markdown 구현 @프룬
+export default function MissionDetailContent({ description }: MissionDetailContentProps) {
+  // descriptionUrl; // 추후 markdown 구현 @프룬
   return (
     <S.MissionDescription>
-      <S.MissionDescriptionText>진행 방식</S.MissionDescriptionText>
-      <br />
-      <br />
-      <S.MissionDescriptionText>
-        미션 진행은 미션 진행 가이드 문서를 따른다.
-      </S.MissionDescriptionText>
-      <br />
-      <br />
-      <S.MissionDescriptionText>
-        리뷰 진행은 리뷰 진행 가이드 문서를 따른다.
-      </S.MissionDescriptionText>
-      <br />
-      <br />
-      <S.MissionDescriptionText>기능 요구 사항</S.MissionDescriptionText>
-      <br />
-      <br />
-      <S.MissionDescriptionText>루터회관 흡연 벌칙 프로그램을 구현한다.</S.MissionDescriptionText>
-      <br />
-      <br />
-      <S.MissionDescriptionText>
-        사용자는 어떤 벌칙을 수행할 것인지를 입력할 수 있어야한다.
-      </S.MissionDescriptionText>
-      <br />
-      <S.MissionDescriptionText>벌칙 목록은 다음과 같다.</S.MissionDescriptionText>
-      <br />
-      <S.MissionDescriptionText>
-        벌칙 시작일 기준 1년안에 10만원을 납부한다.
-      </S.MissionDescriptionText>
-      <br />
-      <S.MissionDescriptionText>
-        벌칙 시작일 기준 30일안에 벌금을 납부하면 8만원이다.
-      </S.MissionDescriptionText>
-      <br />
-      <S.MissionDescriptionText>
-        온라인 교육 프로그램을 이수하면 5만원을 부담한다.
-      </S.MissionDescriptionText>
-      <br />
-      <S.MissionDescriptionText>
-        가까운 보건소에서 금연 프로그램을 이수하면 벌금은 면제된다.
-      </S.MissionDescriptionText>
-      <br />
-      <S.MissionDescriptionText>
-        사용자가 잘못된 값을 입력할 경우 IlegalArgumentException을 발생시킨 후 프로그램은 종료되어야
-        한다.
-      </S.MissionDescriptionText>
-      <br />
-      <br />
-      <S.MissionDescriptionText>예시</S.MissionDescriptionText>
-      <br />
-      <br />
-      <S.MissionDescriptionText>어떤 벌칙을 수행할지 입력해주세요.</S.MissionDescriptionText>
-      <br />
-      <S.MissionDescriptionText>1. 10만원 납부</S.MissionDescriptionText>
-
-      <br />
-      <S.MissionDescriptionText>2. 한달 내에 8만원 납부</S.MissionDescriptionText>
-
-      <br />
-      <S.MissionDescriptionText>
-        3. 온라인 교육 프로그램 이수 후 5만원 납부
-      </S.MissionDescriptionText>
-
-      <br />
-      <S.MissionDescriptionText>4. 금연 프로그램 이수 후 벌금 면제</S.MissionDescriptionText>
-
-      <br />
-      <br />
-      <br />
-      <S.MissionDescriptionText>벌칙 요약입니다.</S.MissionDescriptionText>
-
-      <br />
-      <br />
-      <S.MissionDescriptionText>납부금 : 80,000원</S.MissionDescriptionText>
-
-      <br />
-      <S.MissionDescriptionText>납부 기한 : 2024-08-15</S.MissionDescriptionText>
-
-      <br />
-      <S.MissionDescriptionText>이수 예정 프로그램 : 없음</S.MissionDescriptionText>
-
-      <br />
-      <br />
-      <S.MissionDescriptionText>프로그램을 종료합니다.</S.MissionDescriptionText>
+      <S.MissionDescriptionText>{description}</S.MissionDescriptionText>
     </S.MissionDescription>
   );
 }

--- a/frontend/src/components/MissionDetail/MissionDetailHeader.tsx
+++ b/frontend/src/components/MissionDetail/MissionDetailHeader.tsx
@@ -6,11 +6,7 @@ interface MissionDetailHeaderProps {
   language: string;
 }
 
-export default function MissionDetailHeader({
-  title,
-  thumbnail,
-  language,
-}: MissionDetailHeaderProps) {
+export default function MissionDetailHeader({ title, thumbnail }: MissionDetailHeaderProps) {
   return (
     <S.MissionDetailHeaderContainer>
       <S.ThumbnailWrapper>

--- a/frontend/src/components/MissionList/index.tsx
+++ b/frontend/src/components/MissionList/index.tsx
@@ -1,22 +1,21 @@
-import type { Mission } from '@/types';
+import type { MissionResponse } from '@/types';
 import * as S from './MissionList.styled';
 import { Link } from 'react-router-dom';
 import InfoCard from '@/components/common/InfoCard';
 
 interface MissionListProps {
-  missions: Mission[];
+  missions: MissionResponse[];
 }
 
 export default function MissionList({ missions }: MissionListProps) {
   return (
     <S.MissionList>
-      {missions.map(({ id, thumbnail, title, description }) => (
+      {missions.map(({ id, thumbnail, title }) => (
         <Link key={id} to={`/missions/${id}`}>
           <InfoCard
             id={id}
             thumbnailSrc={thumbnail}
             title={title}
-            description={description}
             thumbnailFallbackText="Mission"
           />
         </Link>

--- a/frontend/src/components/common/InfoCard/index.tsx
+++ b/frontend/src/components/common/InfoCard/index.tsx
@@ -5,8 +5,8 @@ interface InfoCardProps {
   id: number;
   thumbnailSrc: string;
   title: string;
-  description: string;
   thumbnailFallbackText: string;
+  description?: string;
 }
 
 export default function InfoCard({

--- a/frontend/src/hooks/useMissions.ts
+++ b/frontend/src/hooks/useMissions.ts
@@ -1,10 +1,10 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
-import type { Mission } from '@/types';
+import type { MissionResponse } from '@/types';
 import { getAllMissions } from '@/apis/missionAPI';
 import { missionKeys } from './queries/keys';
 
 const useMissions = () => {
-  return useSuspenseQuery<Mission[]>({
+  return useSuspenseQuery<MissionResponse[]>({
     queryKey: missionKeys.all,
     queryFn: getAllMissions,
   });

--- a/frontend/src/mocks/missions.json
+++ b/frontend/src/mocks/missions.json
@@ -4,6 +4,7 @@
     "title": "루터회관 흡연 단속",
     "language": "JAVA",
     "description": "루터회관 흡연 벌칙 프로그램을 구현한다.",
+    "descriptionUrl": "루터회관 흡연 벌칙 프로그램을 구현한다.",
     "thumbnail": "https://file.notion.so/f/f/d5a9d2d0-0fab-48ee-9e8a-13a13de1ac48/38a7f41b-80d7-48ca-97c9-99ceda5c4dbd/smoking.png?id=60756a7a-c50f-4946-ab6e-4177598b926b&table=block&spaceId=d5a9d2d0-0fab-48ee-9e8a-13a13de1ac48&expirationTimestamp=1721174400000&signature=todzUdb5cUyzW4ZQNaHvL-uiCngfMJJAl94RpE1TGEA&downloadName=smoking.png",
     "url": "https://github.com/develup-mission/java-smoking"
   },
@@ -12,6 +13,7 @@
     "title": "단어 퍼즐 게임",
     "language": "JAVA",
     "description": "루터회관 흡연 벌칙 프로그램을 구현한다.",
+    "descriptionUrl": "루터회관 흡연 벌칙 프로그램을 구현한다.",
     "thumbnail": "https://file.notion.so/f/f/d5a9d2d0-0fab-48ee-9e8a-13a13de1ac48/42c240fa-3581-44fe-98ee-88f809996158/word-puzzle.png?id=7bd82f41-0c5b-4880-ac3f-265442c2e428&table=block&spaceId=d5a9d2d0-0fab-48ee-9e8a-13a13de1ac48&expirationTimestamp=1721145600000&signature=UzH3S8xJFU43GXYKhvmmwp5wIrNE6Nss8vIRmbKO8N4&downloadName=word-puzzle.png",
     "url": "https://github.com/develup-mission/java-word-puzzle"
   },
@@ -20,6 +22,7 @@
     "title": "숫자 추리 게임",
     "language": "JAVA",
     "description": "루터회관 흡연 벌칙 프로그램을 구현한다.",
+    "descriptionUrl": "루터회관 흡연 벌칙 프로그램을 구현한다.",
     "thumbnail": "https://file.notion.so/f/f/d5a9d2d0-0fab-48ee-9e8a-13a13de1ac48/ced90f97-7878-4666-96ce-0f39aca1a01e/guessing-number.png?id=c4fe206e-8aa2-4c5a-9895-1630030fc146&table=block&spaceId=d5a9d2d0-0fab-48ee-9e8a-13a13de1ac48&expirationTimestamp=1721145600000&signature=9lPNuetC73atEeb__y3f8ewS8wXvEQEMCfbFZhzYATo&downloadName=guessing-number.png",
     "url": "https://github.com/develup-mission/java-guessing-number"
   }

--- a/frontend/src/pages/MissionDetailPage.tsx
+++ b/frontend/src/pages/MissionDetailPage.tsx
@@ -21,7 +21,7 @@ export default function MissionDetailPage() {
         missionUrl={missionData.url}
         isStarted={missionData.isStarted}
       />
-      <MissionDetailContent descriptionUrl={missionData.description} />
+      <MissionDetailContent description={missionData.description} />
     </S.MissionDetailPageContainer>
   );
 }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,14 +9,19 @@ export interface TabInfo {
 }
 
 //TODO 백엔드에서 내려주는 language 타입이 string이라서 일단 string으로 수정해놓았습니다!
-export interface Mission {
+
+export interface MissionResponse {
   id: number;
   title: string;
   language: string;
-  description: string;
+  descriptionUrl: string;
   thumbnail: string;
   url: string;
   isStarted?: boolean;
+}
+
+export interface Mission extends MissionResponse {
+  description: string;
 }
 
 export interface MissionSubmission {


### PR DESCRIPTION
#### 구현 요약

미션 상세 페이지 하드코딩된 내용을 실제 데이터로 대체했습니다.
마크다운은 아직 적용하지 않아 원문이 그대로 text 형태로 보여집니다.


#### 특이사항
MissionResponse와 Mission이 나뉘었습니다.
MissionResponse는 description을 포함하지 않고 descriptionUrl만 포함하는 서버로부터 받아온 데이터 원본을 나타내는 타입입니다.
Mission은 MissionResponse가 가진 모든 정보와 더불어 description(descriptionUrl을 통해 가져온 텍스트)이 추가된 타입입니다.
<img width="640" alt="스크린샷 2024-08-12 오후 5 03 29" src="https://github.com/user-attachments/assets/1388e06d-3f92-45ba-aaae-718a352082e7">


description이 필요한 상세 조회 api에서는 Mission을 반환하고, description이 필요없는 리스트 조회 api에서는 MissionResponse를 반환합니다.
<img width="794" alt="스크린샷 2024-08-12 오후 5 02 53" src="https://github.com/user-attachments/assets/872011be-9124-4d35-a721-18c109981118">
<img width="746" alt="스크린샷 2024-08-12 오후 5 03 05" src="https://github.com/user-attachments/assets/a3eeb19d-c2ba-4676-bf1a-71a222323bf3">


#### 연관 이슈

close #240

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
