### PR TITLE
진행중인 미션 리스트 API 구현 (Issue #279)

### DIFF
--- a/backend/src/main/java/develup/api/MissionApi.java
+++ b/backend/src/main/java/develup/api/MissionApi.java
@@ -32,6 +32,14 @@ public class MissionApi {
         return ResponseEntity.ok(new ApiResponse<>(responses));
     }
 
+    @GetMapping("/missions/start")
+    @Operation(summary = "미션 목록 조회 API", description = "미션 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<MissionResponse>>> getInProgressMissions(@Auth Accessor accessor) {
+        List<MissionResponse> responses = missionService.getInProgressMissions(accessor.id());
+
+        return ResponseEntity.ok(new ApiResponse<>(responses));
+    }
+
     @GetMapping("/missions/{missionId}")
     @Operation(
             summary = "미션 조회 API",

--- a/backend/src/main/java/develup/application/mission/MissionService.java
+++ b/backend/src/main/java/develup/application/mission/MissionService.java
@@ -6,6 +6,7 @@ import develup.api.exception.ExceptionType;
 import develup.application.auth.Accessor;
 import develup.domain.mission.Mission;
 import develup.domain.mission.MissionRepository;
+import develup.domain.solution.Solution;
 import develup.domain.solution.SolutionRepository;
 import develup.domain.solution.SolutionStatus;
 import org.springframework.stereotype.Service;
@@ -23,6 +24,15 @@ public class MissionService {
 
     public List<MissionResponse> getMissions() {
         return missionRepository.findAll().stream()
+                .map(MissionResponse::from)
+                .toList();
+    }
+
+    public List<MissionResponse> getInProgressMissions(Long memberId) {
+        return solutionRepository.findByMember_IdAndStatus(memberId, SolutionStatus.IN_PROGRESS)
+                .stream()
+                .map(Solution::getMission)
+                .distinct()
                 .map(MissionResponse::from)
                 .toList();
     }

--- a/backend/src/main/java/develup/domain/solution/SolutionRepository.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionRepository.java
@@ -17,4 +17,6 @@ public interface SolutionRepository extends JpaRepository<Solution, Long> {
     List<SolutionSummary> findCompletedSummaries();
 
     Solution findByMember_IdAndMission_IdAndStatus(Long memberId, Long missionId, SolutionStatus status);
+
+    List<Solution> findByMember_IdAndStatus(Long memberId, SolutionStatus status);
 }

--- a/backend/src/test/java/develup/api/MissionApiTest.java
+++ b/backend/src/test/java/develup/api/MissionApiTest.java
@@ -36,9 +36,11 @@ class MissionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data[0].title", equalTo("루터회관 흡연단속")))
                 .andExpect(jsonPath("$.data[0].thumbnail", equalTo("https://thumbnail.com/1.png")))
                 .andExpect(jsonPath("$.data[0].url", equalTo("https://github.com/develup/mission")))
+                .andExpect(jsonPath("$.data[0].summary", equalTo("담배피다 걸린 행성이를 위한 벌금 계산 미션")))
                 .andExpect(jsonPath("$.data[1].title", equalTo("루터회관 흡연단속")))
                 .andExpect(jsonPath("$.data[1].thumbnail", equalTo("https://thumbnail.com/1.png")))
                 .andExpect(jsonPath("$.data[1].url", equalTo("https://github.com/develup/mission")))
+                .andExpect(jsonPath("$.data[1].summary", equalTo("담배피다 걸린 행성이를 위한 벌금 계산 미션")))
                 .andExpect(jsonPath("$.data.length()", is(2)));
     }
 
@@ -60,5 +62,29 @@ class MissionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.descriptionUrl",
                         equalTo("https://raw.githubusercontent.com/develup-mission/mission/main/README.md")))
                 .andExpect(jsonPath("$.data.isStarted", is(false)));
+    }
+
+    @Test
+    @DisplayName("사용자가 시작한 미션 목록을 조회한다.")
+    void getInProgressMissions() throws Exception {
+        List<MissionResponse> responses = List.of(
+                MissionResponse.from(MissionTestData.defaultMission().build()),
+                MissionResponse.from(MissionTestData.defaultMission().build())
+        );
+        BDDMockito.given(missionService.getInProgressMissions(any()))
+                .willReturn(responses);
+
+        mockMvc.perform(get("/missions/start"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].title", equalTo("루터회관 흡연단속")))
+                .andExpect(jsonPath("$.data[0].thumbnail", equalTo("https://thumbnail.com/1.png")))
+                .andExpect(jsonPath("$.data[0].url", equalTo("https://github.com/develup/mission")))
+                .andExpect(jsonPath("$.data[0].summary", equalTo("담배피다 걸린 행성이를 위한 벌금 계산 미션")))
+                .andExpect(jsonPath("$.data[1].title", equalTo("루터회관 흡연단속")))
+                .andExpect(jsonPath("$.data[1].thumbnail", equalTo("https://thumbnail.com/1.png")))
+                .andExpect(jsonPath("$.data[1].url", equalTo("https://github.com/develup/mission")))
+                .andExpect(jsonPath("$.data[1].summary", equalTo("담배피다 걸린 행성이를 위한 벌금 계산 미션")))
+                .andExpect(jsonPath("$.data.length()", is(2)));
     }
 }

--- a/backend/src/test/java/develup/application/mission/MissionServiceTest.java
+++ b/backend/src/test/java/develup/application/mission/MissionServiceTest.java
@@ -11,6 +11,7 @@ import develup.domain.member.Member;
 import develup.domain.member.MemberRepository;
 import develup.domain.mission.Mission;
 import develup.domain.mission.MissionRepository;
+import develup.domain.solution.Solution;
 import develup.domain.solution.SolutionRepository;
 import develup.support.IntegrationTestSupport;
 import develup.support.data.MemberTestData;
@@ -89,5 +90,30 @@ class MissionServiceTest extends IntegrationTestSupport {
         MissionWithStartedResponse response = missionService.getMission(accessor, mission.getId());
 
         assertThat(response.isStarted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("사용자가 시작한 미션 목록을 조회한다.")
+    void getInProgressMissions() {
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+
+        Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
+        Solution solution = SolutionTestData.defaultSolution()
+                .withMember(member)
+                .withMission(mission)
+                .withStatus(IN_PROGRESS)
+                .build();
+
+        Mission otherMission = missionRepository.save(MissionTestData.defaultMission().withTitle("다른 미션").build());
+        Solution otherSolution = SolutionTestData.defaultSolution()
+                .withMember(member)
+                .withMission(otherMission)
+                .withStatus(IN_PROGRESS)
+                .build();
+
+        solutionRepository.saveAll(List.of(solution, otherSolution));
+        List<MissionResponse> inProgressMissions = missionService.getInProgressMissions(member.getId());
+
+        assertThat(inProgressMissions).hasSize(2);
     }
 }


### PR DESCRIPTION
#### 구현 요약

사용자가 시작한 미션 목록을 조회하는 API 추가

#### 연관 이슈

- close #279 

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
