### PR TITLE
해시태깅 기능 구현(issue #273)

### DIFF
--- a/backend/src/main/java/develup/api/SolutionApi.java
+++ b/backend/src/main/java/develup/api/SolutionApi.java
@@ -9,7 +9,7 @@ import develup.application.solution.SolutionResponse;
 import develup.application.solution.SolutionService;
 import develup.application.solution.StartSolutionRequest;
 import develup.application.solution.SubmitSolutionRequest;
-import develup.domain.solution.SolutionSummary;
+import develup.application.solution.SummarizedSolutionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -54,18 +54,18 @@ public class SolutionApi {
 
     @GetMapping("/solutions")
     @Operation(summary = "솔루션 조회 목록 API", description = "솔루션 목록을 조회합니다.")
-    public ResponseEntity<ApiResponse<List<SolutionSummary>>> getSolutions() {
-        List<SolutionSummary> summaries = solutionService.getCompletedSummaries();
+    public ResponseEntity<ApiResponse<List<SummarizedSolutionResponse>>> getSolutions() {
+        List<SummarizedSolutionResponse> responses = solutionService.getCompletedSummaries();
 
-        return ResponseEntity.ok(new ApiResponse<>(summaries));
+        return ResponseEntity.ok(new ApiResponse<>(responses));
     }
 
     @GetMapping("/solutions/{id}")
     @Operation(summary = "솔루션 조회 API", description = "솔루션을 조회합니다.")
     public ResponseEntity<ApiResponse<SolutionResponse>> getSolution(@PathVariable Long id) {
-        SolutionResponse solutionResponse = solutionService.getById(id);
+        SolutionResponse response = solutionService.getById(id);
 
-        return ResponseEntity.ok(new ApiResponse<>(solutionResponse));
+        return ResponseEntity.ok(new ApiResponse<>(response));
     }
 
     @GetMapping("/solutions/mine")

--- a/backend/src/main/java/develup/api/exception/ExceptionType.java
+++ b/backend/src/main/java/develup/api/exception/ExceptionType.java
@@ -20,7 +20,10 @@ public enum ExceptionType {
     COMMENT_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 댓글입니다."),
     CANNOT_REPLY_TO_REPLY(HttpStatus.BAD_REQUEST, "답글에는 답글을 작성할 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
-    COMMENT_NOT_WRITTEN_BY_MEMBER(HttpStatus.FORBIDDEN, "작성자만 댓글을 삭제할 수 있습니다.");
+    COMMENT_NOT_WRITTEN_BY_MEMBER(HttpStatus.FORBIDDEN, "작성자만 댓글을 삭제할 수 있습니다."),
+    DUPLICATED_HASHTAG(HttpStatus.BAD_REQUEST, "중복된 해시태그입니다."),
+
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/backend/src/main/java/develup/application/hashtag/HashTagResponse.java
+++ b/backend/src/main/java/develup/application/hashtag/HashTagResponse.java
@@ -1,0 +1,13 @@
+package develup.application.hashtag;
+
+import develup.domain.hashtag.HashTag;
+
+public record HashTagResponse(Long id, String name) {
+
+    public static HashTagResponse from(HashTag hashTag) {
+        return new HashTagResponse(
+                hashTag.getId(),
+                hashTag.getName()
+        );
+    }
+}

--- a/backend/src/main/java/develup/application/mission/MissionResponse.java
+++ b/backend/src/main/java/develup/application/mission/MissionResponse.java
@@ -1,22 +1,33 @@
 package develup.application.mission;
 
+import java.util.List;
+import develup.application.hashtag.HashTagResponse;
 import develup.domain.mission.Mission;
+import develup.domain.mission.MissionHashTag;
 
 public record MissionResponse(
         Long id,
         String title,
         String thumbnail,
         String summary,
-        String url
+        String url,
+        List<HashTagResponse> hashTag
 ) {
 
     public static MissionResponse from(Mission mission) {
+        List<HashTagResponse> hashTagResponses = mission.getHashTags()
+                .stream()
+                .map(MissionHashTag::getHashTag)
+                .map(HashTagResponse::from)
+                .toList();
+
         return new MissionResponse(
                 mission.getId(),
                 mission.getTitle(),
                 mission.getThumbnail(),
                 mission.getSummary(),
-                mission.getUrl()
+                mission.getUrl(),
+                hashTagResponses
         );
     }
 }

--- a/backend/src/main/java/develup/application/mission/MissionResponse.java
+++ b/backend/src/main/java/develup/application/mission/MissionResponse.java
@@ -11,7 +11,7 @@ public record MissionResponse(
         String thumbnail,
         String summary,
         String url,
-        List<HashTagResponse> hashTag
+        List<HashTagResponse> hashTags
 ) {
 
     public static MissionResponse from(Mission mission) {

--- a/backend/src/main/java/develup/application/mission/MissionService.java
+++ b/backend/src/main/java/develup/application/mission/MissionService.java
@@ -40,7 +40,7 @@ public class MissionService {
     }
 
     public MissionWithStartedResponse getMission(Accessor accessor, Long missionId) {
-        Mission mission = missionRepository.findWithHashTagsById(missionId)
+        Mission mission = missionRepository.findHashTaggedMissionById(missionId)
                 .orElseThrow(() -> new DevelupException(ExceptionType.MISSION_NOT_FOUND));
 
         if (accessor.isGuest()) {

--- a/backend/src/main/java/develup/application/mission/MissionService.java
+++ b/backend/src/main/java/develup/application/mission/MissionService.java
@@ -25,7 +25,7 @@ public class MissionService {
     }
 
     public List<MissionResponse> getMissions() {
-        return missionRepository.findAll().stream()
+        return missionRepository.findAllHashTaggedMission().stream()
                 .map(MissionResponse::from)
                 .toList();
     }

--- a/backend/src/main/java/develup/application/mission/MissionService.java
+++ b/backend/src/main/java/develup/application/mission/MissionService.java
@@ -40,7 +40,7 @@ public class MissionService {
     }
 
     public MissionWithStartedResponse getMission(Accessor accessor, Long missionId) {
-        Mission mission = missionRepository.findById(missionId)
+        Mission mission = missionRepository.findWithHashTagsById(missionId)
                 .orElseThrow(() -> new DevelupException(ExceptionType.MISSION_NOT_FOUND));
 
         if (accessor.isGuest()) {

--- a/backend/src/main/java/develup/application/mission/MissionWithStartedResponse.java
+++ b/backend/src/main/java/develup/application/mission/MissionWithStartedResponse.java
@@ -1,6 +1,9 @@
 package develup.application.mission;
 
+import java.util.List;
+import develup.application.hashtag.HashTagResponse;
 import develup.domain.mission.Mission;
+import develup.domain.mission.MissionHashTag;
 
 public record MissionWithStartedResponse(
         Long id,
@@ -8,17 +11,25 @@ public record MissionWithStartedResponse(
         String descriptionUrl,
         String thumbnail,
         String url,
-        boolean isStarted
+        boolean isStarted,
+        List<HashTagResponse> hashTag
 ) {
 
     public static MissionWithStartedResponse of(Mission mission, boolean isStarted) {
+        List<HashTagResponse> hashTagResponses = mission.getHashTags()
+                .stream()
+                .map(MissionHashTag::getHashTag)
+                .map(HashTagResponse::from)
+                .toList();
+
         return new MissionWithStartedResponse(
                 mission.getId(),
                 mission.getTitle(),
                 mission.getDescriptionUrl(),
                 mission.getThumbnail(),
                 mission.getUrl(),
-                isStarted
+                isStarted,
+                hashTagResponses
         );
     }
 

--- a/backend/src/main/java/develup/application/mission/MissionWithStartedResponse.java
+++ b/backend/src/main/java/develup/application/mission/MissionWithStartedResponse.java
@@ -12,7 +12,7 @@ public record MissionWithStartedResponse(
         String thumbnail,
         String url,
         boolean isStarted,
-        List<HashTagResponse> hashTag
+        List<HashTagResponse> hashTags
 ) {
 
     public static MissionWithStartedResponse of(Mission mission, boolean isStarted) {

--- a/backend/src/main/java/develup/application/solution/SolutionService.java
+++ b/backend/src/main/java/develup/application/solution/SolutionService.java
@@ -13,7 +13,6 @@ import develup.domain.solution.Solution;
 import develup.domain.solution.SolutionRepository;
 import develup.domain.solution.SolutionStatus;
 import develup.domain.solution.SolutionSubmit;
-import develup.domain.solution.SolutionSummary;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -104,8 +103,10 @@ public class SolutionService {
         return SolutionResponse.from(solution);
     }
 
-    public List<SolutionSummary> getCompletedSummaries() {
-        return solutionRepository.findCompletedSummaries();
+    public List<SummarizedSolutionResponse> getCompletedSummaries() {
+        return solutionRepository.findAllCompletedSolution().stream()
+                .map(SummarizedSolutionResponse::from)
+                .toList();
     }
 
     public List<MySolutionResponse> getSubmittedSolutionsByMemberId(Long memberId) {

--- a/backend/src/main/java/develup/application/solution/SummarizedSolutionResponse.java
+++ b/backend/src/main/java/develup/application/solution/SummarizedSolutionResponse.java
@@ -10,7 +10,7 @@ public record SummarizedSolutionResponse(
         String title,
         String thumbnail,
         String description,
-        List<HashTagResponse> hashTag
+        List<HashTagResponse> hashTags
 ) {
 
     public static SummarizedSolutionResponse from(Solution solution) {

--- a/backend/src/main/java/develup/application/solution/SummarizedSolutionResponse.java
+++ b/backend/src/main/java/develup/application/solution/SummarizedSolutionResponse.java
@@ -1,0 +1,2 @@
+package develup.application.solution;class SolutionSummaryResponse {
+}

--- a/backend/src/main/java/develup/application/solution/SummarizedSolutionResponse.java
+++ b/backend/src/main/java/develup/application/solution/SummarizedSolutionResponse.java
@@ -1,2 +1,30 @@
-package develup.application.solution;class SolutionSummaryResponse {
+package develup.application.solution;
+
+import java.util.List;
+import develup.application.hashtag.HashTagResponse;
+import develup.domain.mission.MissionHashTag;
+import develup.domain.solution.Solution;
+
+public record SummarizedSolutionResponse(
+        Long id,
+        String title,
+        String thumbnail,
+        String description,
+        List<HashTagResponse> hashTag
+) {
+
+    public static SummarizedSolutionResponse from(Solution solution) {
+        List<HashTagResponse> hashTagResponses = solution.getHashTags().stream()
+                .map(MissionHashTag::getHashTag)
+                .map(HashTagResponse::from)
+                .toList();
+
+        return new SummarizedSolutionResponse(
+                solution.getId(),
+                solution.getTitle(),
+                solution.getMissionThumbnail(),
+                solution.getDescription(),
+                hashTagResponses
+        );
+    }
 }

--- a/backend/src/main/java/develup/domain/hashtag/HashTag.java
+++ b/backend/src/main/java/develup/domain/hashtag/HashTag.java
@@ -1,0 +1,55 @@
+package develup.domain.hashtag;
+
+import java.util.Objects;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+@Entity
+public class HashTag {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    protected HashTag() {
+    }
+
+    public HashTag(String name) {
+        this(null, name);
+    }
+
+    public HashTag(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof HashTag hashTag)) {
+            return false;
+        }
+
+        return this.getId() != null && Objects.equals(getId(), hashTag.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
+    }
+}

--- a/backend/src/main/java/develup/domain/hashtag/HashTag.java
+++ b/backend/src/main/java/develup/domain/hashtag/HashTag.java
@@ -4,13 +4,14 @@ import java.util.Objects;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity
 public class HashTag {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)

--- a/backend/src/main/java/develup/domain/hashtag/HashTagRepository.java
+++ b/backend/src/main/java/develup/domain/hashtag/HashTagRepository.java
@@ -1,0 +1,6 @@
+package develup.domain.hashtag;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HashTagRepository extends JpaRepository<HashTag, Long> {
+}

--- a/backend/src/main/java/develup/domain/mission/Mission.java
+++ b/backend/src/main/java/develup/domain/mission/Mission.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import org.hibernate.annotations.BatchSize;
 
 @Entity
 public class Mission {
@@ -36,6 +37,7 @@ public class Mission {
     @Column(nullable = false)
     private String url;
 
+    @BatchSize(size = 100)
     @OneToMany(mappedBy = "mission", cascade = CascadeType.PERSIST)
     private List<MissionHashTag> hashTags = new ArrayList<>();
 

--- a/backend/src/main/java/develup/domain/mission/Mission.java
+++ b/backend/src/main/java/develup/domain/mission/Mission.java
@@ -1,10 +1,18 @@
 package develup.domain.mission;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import develup.api.exception.DevelupException;
+import develup.api.exception.ExceptionType;
+import develup.domain.hashtag.HashTag;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 
 @Entity
 public class Mission {
@@ -28,19 +36,63 @@ public class Mission {
     @Column(nullable = false)
     private String url;
 
+    @OneToMany(mappedBy = "mission", cascade = CascadeType.PERSIST)
+    private List<MissionHashTag> hashTags = new ArrayList<>();
+
     protected Mission() {
     }
 
-    public Mission(String title, String thumbnail, String summary, String url) {
-        this(null, title, thumbnail, summary, url);
+    public Mission(String title, String thumbnail, String summary, String url, List<HashTag> hashTags) {
+        this(null, title, thumbnail, summary, url, hashTags);
     }
 
-    public Mission(Long id, String title, String thumbnail, String summary, String url) {
+    public Mission(Long id, String title, String thumbnail,String summary, String url, List<HashTag> hashTags) {
         this.id = id;
         this.title = title;
         this.thumbnail = thumbnail;
         this.summary = summary;
         this.url = url;
+        this.hashTags.addAll(mapToMissionHashTag(hashTags));
+    }
+
+    public void tagAll(List<HashTag> tags) {
+        validateDuplicated(tags);
+        validateAlreadyTagged(tags);
+
+        hashTags.addAll(mapToMissionHashTag(tags));
+    }
+
+    private void validateAlreadyTagged(List<HashTag> tags) {
+        boolean alreadyTagged = hashTags.stream()
+                .map(MissionHashTag::getHashTag)
+                .anyMatch(tags::contains);
+
+        if (alreadyTagged) {
+            throw new DevelupException(ExceptionType.DUPLICATED_HASHTAG);
+        }
+    }
+
+    private void validateDuplicated(List<HashTag> tags) {
+        int uniqueSize = tags.stream()
+                .distinct()
+                .toList()
+                .size();
+
+        if (uniqueSize != tags.size()) {
+            throw new DevelupException(ExceptionType.DUPLICATED_HASHTAG);
+        }
+    }
+
+    private List<MissionHashTag> mapToMissionHashTag(List<HashTag> tags) {
+        return tags.stream()
+                .map(it -> new MissionHashTag(this, it))
+                .toList();
+    }
+
+    public String getDescriptionUrl() {
+        String[] split = url.split("/");
+
+        return DESCRIPTION_BASE_URL_PREFIX + split[split.length - 1] + DESCRIPTION_BASE_URL_SUFFIX;
     }
 
     public Long getId() {
@@ -63,9 +115,7 @@ public class Mission {
         return url;
     }
 
-    public String getDescriptionUrl() {
-        String[] split = url.split("/");
-
-        return DESCRIPTION_BASE_URL_PREFIX + split[split.length - 1] + DESCRIPTION_BASE_URL_SUFFIX;
+    public List<MissionHashTag> getHashTags() {
+        return Collections.unmodifiableList(hashTags);
     }
 }

--- a/backend/src/main/java/develup/domain/mission/Mission.java
+++ b/backend/src/main/java/develup/domain/mission/Mission.java
@@ -46,7 +46,7 @@ public class Mission {
         this(null, title, thumbnail, summary, url, hashTags);
     }
 
-    public Mission(Long id, String title, String thumbnail,String summary, String url, List<HashTag> hashTags) {
+    public Mission(Long id, String title, String thumbnail, String summary, String url, List<HashTag> hashTags) {
         this.id = id;
         this.title = title;
         this.thumbnail = thumbnail;

--- a/backend/src/main/java/develup/domain/mission/Mission.java
+++ b/backend/src/main/java/develup/domain/mission/Mission.java
@@ -1,8 +1,9 @@
 package develup.domain.mission;
 
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import develup.api.exception.DevelupException;
 import develup.api.exception.ExceptionType;
 import develup.domain.hashtag.HashTag;
@@ -13,7 +14,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-import org.hibernate.annotations.BatchSize;
+import jakarta.persistence.OrderBy;
 
 @Entity
 public class Mission {
@@ -37,9 +38,9 @@ public class Mission {
     @Column(nullable = false)
     private String url;
 
-    @BatchSize(size = 100)
+    @OrderBy(value = "id ASC")
     @OneToMany(mappedBy = "mission", cascade = CascadeType.PERSIST)
-    private List<MissionHashTag> hashTags = new ArrayList<>();
+    private Set<MissionHashTag> hashTags = new LinkedHashSet<>();
 
     protected Mission() {
     }
@@ -64,16 +65,6 @@ public class Mission {
         hashTags.addAll(mapToMissionHashTag(tags));
     }
 
-    private void validateAlreadyTagged(List<HashTag> tags) {
-        boolean alreadyTagged = hashTags.stream()
-                .map(MissionHashTag::getHashTag)
-                .anyMatch(tags::contains);
-
-        if (alreadyTagged) {
-            throw new DevelupException(ExceptionType.DUPLICATED_HASHTAG);
-        }
-    }
-
     private void validateDuplicated(List<HashTag> tags) {
         int uniqueSize = tags.stream()
                 .distinct()
@@ -81,6 +72,16 @@ public class Mission {
                 .size();
 
         if (uniqueSize != tags.size()) {
+            throw new DevelupException(ExceptionType.DUPLICATED_HASHTAG);
+        }
+    }
+
+    private void validateAlreadyTagged(List<HashTag> tags) {
+        boolean alreadyTagged = hashTags.stream()
+                .map(MissionHashTag::getHashTag)
+                .anyMatch(tags::contains);
+
+        if (alreadyTagged) {
             throw new DevelupException(ExceptionType.DUPLICATED_HASHTAG);
         }
     }
@@ -117,7 +118,7 @@ public class Mission {
         return url;
     }
 
-    public List<MissionHashTag> getHashTags() {
-        return Collections.unmodifiableList(hashTags);
+    public Set<MissionHashTag> getHashTags() {
+        return Collections.unmodifiableSet(hashTags);
     }
 }

--- a/backend/src/main/java/develup/domain/mission/MissionHashTag.java
+++ b/backend/src/main/java/develup/domain/mission/MissionHashTag.java
@@ -9,7 +9,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
 @Entity
-public class MissionHashTag {
+class MissionHashTag {
 
     @Id
     @GeneratedValue

--- a/backend/src/main/java/develup/domain/mission/MissionHashTag.java
+++ b/backend/src/main/java/develup/domain/mission/MissionHashTag.java
@@ -1,0 +1,50 @@
+package develup.domain.mission;
+
+import develup.domain.hashtag.HashTag;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class MissionHashTag {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private Mission mission;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
+    private HashTag hashTag;
+
+    protected MissionHashTag() {
+    }
+
+    public MissionHashTag(Mission mission, HashTag hashTag) {
+        this(null, mission, hashTag);
+    }
+
+    public MissionHashTag(Long id, Mission mission, HashTag hashTag) {
+        this.id = id;
+        this.mission = mission;
+        this.hashTag = hashTag;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Mission getMission() {
+        return mission;
+    }
+
+    public HashTag getHashTag() {
+        return hashTag;
+    }
+}

--- a/backend/src/main/java/develup/domain/mission/MissionHashTag.java
+++ b/backend/src/main/java/develup/domain/mission/MissionHashTag.java
@@ -4,15 +4,16 @@ import develup.domain.hashtag.HashTag;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
 @Entity
-class MissionHashTag {
+public class MissionHashTag {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/develup/domain/mission/MissionHashTags.java
+++ b/backend/src/main/java/develup/domain/mission/MissionHashTags.java
@@ -1,0 +1,69 @@
+package develup.domain.mission;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import develup.api.exception.DevelupException;
+import develup.api.exception.ExceptionType;
+import develup.domain.hashtag.HashTag;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+
+@Embeddable
+class MissionHashTags {
+
+    @OrderBy(value = "id ASC")
+    @OneToMany(mappedBy = "mission", cascade = CascadeType.PERSIST)
+    private Set<MissionHashTag> hashTags = new LinkedHashSet<>();
+
+    protected MissionHashTags() {
+    }
+
+    public MissionHashTags(Mission mission, List<HashTag> hashTags) {
+        validateDuplicated(hashTags);
+
+        this.hashTags = mapToMissionHashTag(mission, hashTags);
+    }
+
+    public void addAll(Mission target, List<HashTag> hashTags) {
+        validateDuplicated(hashTags);
+        validateAlreadyTagged(hashTags);
+
+        this.hashTags.addAll(mapToMissionHashTag(target, hashTags));
+    }
+
+    private void validateDuplicated(List<HashTag> hashTags) {
+        int uniqueSize = hashTags.stream()
+                .distinct()
+                .toList()
+                .size();
+
+        if (uniqueSize != hashTags.size()) {
+            throw new DevelupException(ExceptionType.DUPLICATED_HASHTAG);
+        }
+    }
+
+    private void validateAlreadyTagged(List<HashTag> hashTags) {
+        boolean alreadyTagged = this.hashTags.stream()
+                .map(MissionHashTag::getHashTag)
+                .anyMatch(hashTags::contains);
+
+        if (alreadyTagged) {
+            throw new DevelupException(ExceptionType.DUPLICATED_HASHTAG);
+        }
+    }
+
+    private Set<MissionHashTag> mapToMissionHashTag(Mission target, List<HashTag> hashTags) {
+        return hashTags.stream()
+                .map(it -> new MissionHashTag(target, it))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    public Set<MissionHashTag> getHashTags() {
+        return Collections.unmodifiableSet(hashTags);
+    }
+}

--- a/backend/src/main/java/develup/domain/mission/MissionRepository.java
+++ b/backend/src/main/java/develup/domain/mission/MissionRepository.java
@@ -13,7 +13,8 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     @Query("""
             SELECT DISTINCT m
             FROM Mission m
-            JOIN FETCH m.hashTags ht
+            JOIN FETCH m.hashTags mht
+            JOIN FETCH mht.hashTag ht
             WHERE m.id = :id
             """)
     Optional<Mission> findWithHashTagsById(Long id);

--- a/backend/src/main/java/develup/domain/mission/MissionRepository.java
+++ b/backend/src/main/java/develup/domain/mission/MissionRepository.java
@@ -17,7 +17,7 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
             JOIN FETCH mht.hashTag ht
             WHERE m.id = :id
             """)
-    Optional<Mission> findWithHashTagsById(Long id);
+    Optional<Mission> findHashTaggedMissionById(Long id);
 
     @Query("""
             SELECT DISTINCT m

--- a/backend/src/main/java/develup/domain/mission/MissionRepository.java
+++ b/backend/src/main/java/develup/domain/mission/MissionRepository.java
@@ -18,4 +18,12 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
             WHERE m.id = :id
             """)
     Optional<Mission> findWithHashTagsById(Long id);
+
+    @Query("""
+            SELECT DISTINCT m
+            FROM Mission m
+            JOIN FETCH m.hashTags mht
+            JOIN FETCH mht.hashTag ht
+            """)
+    List<Mission> findAllHashTaggedMission();
 }

--- a/backend/src/main/java/develup/domain/mission/MissionRepository.java
+++ b/backend/src/main/java/develup/domain/mission/MissionRepository.java
@@ -13,8 +13,8 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     @Query("""
             SELECT DISTINCT m
             FROM Mission m
-            JOIN FETCH m.hashTags mht
-            JOIN FETCH mht.hashTag ht
+            JOIN FETCH m.missionHashTags.hashTags mhts
+            JOIN FETCH mhts.hashTag ht
             WHERE m.id = :id
             """)
     Optional<Mission> findHashTaggedMissionById(Long id);
@@ -22,8 +22,8 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
     @Query("""
             SELECT DISTINCT m
             FROM Mission m
-            JOIN FETCH m.hashTags mht
-            JOIN FETCH mht.hashTag ht
+            JOIN FETCH m.missionHashTags.hashTags mhts
+            JOIN FETCH mhts.hashTag ht
             """)
     List<Mission> findAllHashTaggedMission();
 }

--- a/backend/src/main/java/develup/domain/mission/MissionRepository.java
+++ b/backend/src/main/java/develup/domain/mission/MissionRepository.java
@@ -1,10 +1,7 @@
 package develup.domain.mission;
 
-<<<<<<< HEAD
 import java.util.List;
-=======
 import java.util.Optional;
->>>>>>> e601a20 (feat: 해시태그 존재 미션 단건 조회 기능 구현)
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/backend/src/main/java/develup/domain/mission/MissionRepository.java
+++ b/backend/src/main/java/develup/domain/mission/MissionRepository.java
@@ -1,6 +1,10 @@
 package develup.domain.mission;
 
+<<<<<<< HEAD
 import java.util.List;
+=======
+import java.util.Optional;
+>>>>>>> e601a20 (feat: 해시태그 존재 미션 단건 조회 기능 구현)
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -8,4 +12,12 @@ public interface MissionRepository extends JpaRepository<Mission, Long> {
 
     @Query("SELECT m.url FROM Mission m")
     List<String> findUrl();
+
+    @Query("""
+            SELECT DISTINCT m
+            FROM Mission m
+            JOIN FETCH m.hashTags ht
+            WHERE m.id = :id
+            """)
+    Optional<Mission> findWithHashTagsById(Long id);
 }

--- a/backend/src/main/java/develup/domain/solution/Solution.java
+++ b/backend/src/main/java/develup/domain/solution/Solution.java
@@ -105,10 +105,6 @@ public class Solution {
         return mission;
     }
 
-    public String getMissionThumbnail() {
-        return mission.getThumbnail();
-    }
-
     public Member getMember() {
         return member;
     }

--- a/backend/src/main/java/develup/domain/solution/Solution.java
+++ b/backend/src/main/java/develup/domain/solution/Solution.java
@@ -1,9 +1,11 @@
 package develup.domain.solution;
 
+import java.util.List;
 import develup.api.exception.DevelupException;
 import develup.api.exception.ExceptionType;
 import develup.domain.member.Member;
 import develup.domain.mission.Mission;
+import develup.domain.mission.MissionHashTag;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -125,5 +127,13 @@ public class Solution {
 
     public SolutionStatus getStatus() {
         return status;
+    }
+
+    public String getMissionThumbnail() {
+        return mission.getThumbnail();
+    }
+
+    public List<MissionHashTag> getHashTags() {
+        return mission.getHashTags();
     }
 }

--- a/backend/src/main/java/develup/domain/solution/Solution.java
+++ b/backend/src/main/java/develup/domain/solution/Solution.java
@@ -1,6 +1,6 @@
 package develup.domain.solution;
 
-import java.util.List;
+import java.util.Set;
 import develup.api.exception.DevelupException;
 import develup.api.exception.ExceptionType;
 import develup.domain.member.Member;
@@ -133,7 +133,7 @@ public class Solution {
         return mission.getThumbnail();
     }
 
-    public List<MissionHashTag> getHashTags() {
+    public Set<MissionHashTag> getHashTags() {
         return mission.getHashTags();
     }
 }

--- a/backend/src/main/java/develup/domain/solution/SolutionRepository.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionRepository.java
@@ -10,12 +10,13 @@ public interface SolutionRepository extends JpaRepository<Solution, Long> {
     boolean existsByMember_IdAndMission_IdAndStatus(Long memberId, Long missionId, SolutionStatus status);
 
     @Query("""
-            SELECT new develup.domain.solution.SolutionSummary(s.id, m.thumbnail, s.title.value, s.description)
+            SELECT DISTINCT s
             FROM Solution s
-            JOIN s.mission m
+            JOIN FETCH s.mission m
             WHERE s.status = 'COMPLETED'
+            ORDER BY s.id DESC
             """)
-    List<SolutionSummary> findCompletedSummaries();
+    List<Solution> findAllCompletedSolution();
 
     List<Solution> findAllByMember_IdAndStatus(Long memberId, SolutionStatus status);
 

--- a/backend/src/main/java/develup/domain/solution/SolutionRepository.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionRepository.java
@@ -10,9 +10,11 @@ public interface SolutionRepository extends JpaRepository<Solution, Long> {
     boolean existsByMember_IdAndMission_IdAndStatus(Long memberId, Long missionId, SolutionStatus status);
 
     @Query("""
-            SELECT s
+            SELECT DISTINCT s
             FROM Solution s
             JOIN FETCH s.mission m
+            JOIN FETCH m.hashTags mht
+            JOIN FETCH mht.hashTag ht
             WHERE s.status = 'COMPLETED'
             ORDER BY s.id DESC
             """)

--- a/backend/src/main/java/develup/domain/solution/SolutionRepository.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionRepository.java
@@ -10,7 +10,7 @@ public interface SolutionRepository extends JpaRepository<Solution, Long> {
     boolean existsByMember_IdAndMission_IdAndStatus(Long memberId, Long missionId, SolutionStatus status);
 
     @Query("""
-            SELECT DISTINCT s
+            SELECT s
             FROM Solution s
             JOIN FETCH s.mission m
             WHERE s.status = 'COMPLETED'

--- a/backend/src/main/java/develup/domain/solution/SolutionRepository.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionRepository.java
@@ -13,8 +13,8 @@ public interface SolutionRepository extends JpaRepository<Solution, Long> {
             SELECT DISTINCT s
             FROM Solution s
             JOIN FETCH s.mission m
-            JOIN FETCH m.hashTags mht
-            JOIN FETCH mht.hashTag ht
+            JOIN FETCH m.missionHashTags.hashTags mhts
+            JOIN FETCH mhts.hashTag ht
             WHERE s.status = 'COMPLETED'
             ORDER BY s.id DESC
             """)

--- a/backend/src/main/java/develup/domain/solution/SolutionSummary.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionSummary.java
@@ -1,9 +1,0 @@
-package develup.domain.solution;
-
-public record SolutionSummary(
-        Long id,
-        String thumbnail,
-        String title,
-        String description
-) {
-}

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -11,9 +11,25 @@ INSERT INTO mission (title, thumbnail, summary, url)
 VALUES ('루터회관 흡연 단속', 'https://raw.githubusercontent.com/develup-mission/docs/main/image/java-smoking.png',
         '담배피다 걸린 행성이를 위한 벌금 계산 미션', 'https://github.com/develup-mission/java-smoking');
 INSERT INTO mission (title, thumbnail, summary, url)
-VALUES ('java-guessing-number',
-        'https://raw.githubusercontent.com/develup-mission/docs/main/image/java-guessing-number.png', '숫자를 맞춰보자',
-        'https://github.com/develup-mission/java-guessing-number');
+VALUES ('숫자 맞추기 게임', 'https://raw.githubusercontent.com/develup-mission/docs/main/image/java-guessing-number.png',
+        '숫자를 맞춰보자', 'https://github.com/develup-mission/java-guessing-number');
+
+INSERT INTO hash_tag (name) VALUES ('JAVA');
+INSERT INTO hash_tag (name) VALUES ('객체지향');
+INSERT INTO hash_tag (name) VALUES ('TDD');
+INSERT INTO hash_tag (name) VALUES ('클린코드');
+INSERT INTO hash_tag (name) VALUES ('레벨1');
+
+INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (1, 1);
+INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (1, 2);
+INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (1, 3);
+INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (1, 4);
+INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (1, 5);
+INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (2, 1);
+INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (2, 2);
+INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (2, 3);
+INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (2, 4);
+INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (2, 5);
 
 INSERT INTO solution (mission_id, member_id, title, description, url, status)
 VALUES (1, 1, '릴리 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED');
@@ -49,4 +65,3 @@ INSERT INTO solution_comment (solution_id, member_id, content, parent_comment_id
 VALUES (1, 1, '2-2', 2, '2021-08-01 00:00:00', '2021-08-01 00:00:00');
 INSERT INTO solution_comment (solution_id, member_id, content, parent_comment_id, deleted_at, created_at)
 VALUES (1, 1, '1-2', 1, NULL, '2021-08-01 00:00:00');
-

--- a/backend/src/test/java/develup/api/MissionApiTest.java
+++ b/backend/src/test/java/develup/api/MissionApiTest.java
@@ -11,7 +11,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 import develup.application.mission.MissionResponse;
 import develup.application.mission.MissionWithStartedResponse;
+import develup.domain.hashtag.HashTag;
 import develup.domain.mission.Mission;
+import develup.support.data.HashTagTestData;
 import develup.support.data.MissionTestData;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,7 +48,13 @@ class MissionApiTest extends ApiTestSupport {
     @Test
     @DisplayName("미션을 조회한다.")
     void getMission() throws Exception {
-        Mission mission = MissionTestData.defaultMission().withId(1L).build();
+        HashTag hashTag = HashTagTestData.defaultHashTag()
+                .withId(1L)
+                .build();
+        Mission mission = MissionTestData.defaultMission()
+                .withId(1L)
+                .withHashTags(List.of(hashTag))
+                .build();
         MissionWithStartedResponse response = MissionWithStartedResponse.of(mission, false);
         BDDMockito.given(missionService.getMission(any(), any()))
                 .willReturn(response);
@@ -60,7 +68,9 @@ class MissionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.url", equalTo("https://github.com/develup-mission/java-smoking")))
                 .andExpect(jsonPath("$.data.descriptionUrl",
                         equalTo("https://raw.githubusercontent.com/develup-mission/java-smoking/main/README.md")))
-                .andExpect(jsonPath("$.data.isStarted", is(false)));
+                .andExpect(jsonPath("$.data.isStarted", is(false)))
+                .andExpect(jsonPath("$.data.hashTag[0].id", equalTo(1)))
+                .andExpect(jsonPath("$.data.hashTag[0].name", equalTo("JAVA")));
     }
 
     @Test

--- a/backend/src/test/java/develup/api/MissionApiTest.java
+++ b/backend/src/test/java/develup/api/MissionApiTest.java
@@ -69,8 +69,8 @@ class MissionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.descriptionUrl",
                         equalTo("https://raw.githubusercontent.com/develup-mission/java-smoking/main/README.md")))
                 .andExpect(jsonPath("$.data.isStarted", is(false)))
-                .andExpect(jsonPath("$.data.hashTag[0].id", equalTo(1)))
-                .andExpect(jsonPath("$.data.hashTag[0].name", equalTo("JAVA")));
+                .andExpect(jsonPath("$.data.hashTags[0].id", equalTo(1)))
+                .andExpect(jsonPath("$.data.hashTags[0].name", equalTo("JAVA")));
     }
 
     @Test

--- a/backend/src/test/java/develup/api/MissionApiTest.java
+++ b/backend/src/test/java/develup/api/MissionApiTest.java
@@ -24,9 +24,10 @@ class MissionApiTest extends ApiTestSupport {
     @Test
     @DisplayName("미션 목록을 조회한다.")
     void getMissions() throws Exception {
+        Mission mission = createMission();
         List<MissionResponse> responses = List.of(
-                MissionResponse.from(MissionTestData.defaultMission().build()),
-                MissionResponse.from(MissionTestData.defaultMission().build())
+                MissionResponse.from(mission),
+                MissionResponse.from(mission)
         );
         BDDMockito.given(missionService.getMissions())
                 .willReturn(responses);
@@ -38,23 +39,22 @@ class MissionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data[0].thumbnail", equalTo("https://thumbnail.com/1.png")))
                 .andExpect(jsonPath("$.data[0].url", equalTo("https://github.com/develup-mission/java-smoking")))
                 .andExpect(jsonPath("$.data[0].summary", equalTo("담배피다 걸린 행성이를 위한 벌금 계산 미션")))
+                .andExpect(jsonPath("$.data[0].hashTags[0].id", equalTo(1)))
+                .andExpect(jsonPath("$.data[0].hashTags[0].name", equalTo("JAVA")))
                 .andExpect(jsonPath("$.data[1].title", equalTo("루터회관 흡연단속")))
                 .andExpect(jsonPath("$.data[1].thumbnail", equalTo("https://thumbnail.com/1.png")))
                 .andExpect(jsonPath("$.data[1].url", equalTo("https://github.com/develup-mission/java-smoking")))
                 .andExpect(jsonPath("$.data[1].summary", equalTo("담배피다 걸린 행성이를 위한 벌금 계산 미션")))
+                .andExpect(jsonPath("$.data[1].thumbnail", equalTo("https://thumbnail.com/1.png")))
+                .andExpect(jsonPath("$.data[1].hashTags[0].id", equalTo(1)))
+                .andExpect(jsonPath("$.data[1].hashTags[0].name", equalTo("JAVA")))
                 .andExpect(jsonPath("$.data.length()", is(2)));
     }
 
     @Test
     @DisplayName("미션을 조회한다.")
     void getMission() throws Exception {
-        HashTag hashTag = HashTagTestData.defaultHashTag()
-                .withId(1L)
-                .build();
-        Mission mission = MissionTestData.defaultMission()
-                .withId(1L)
-                .withHashTags(List.of(hashTag))
-                .build();
+        Mission mission = createMission();
         MissionWithStartedResponse response = MissionWithStartedResponse.of(mission, false);
         BDDMockito.given(missionService.getMission(any(), any()))
                 .willReturn(response);
@@ -95,5 +95,16 @@ class MissionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data[1].url", equalTo("https://github.com/develup-mission/java-smoking")))
                 .andExpect(jsonPath("$.data[1].summary", equalTo("담배피다 걸린 행성이를 위한 벌금 계산 미션")))
                 .andExpect(jsonPath("$.data.length()", is(2)));
+    }
+
+    private Mission createMission() {
+        HashTag hashTag = HashTagTestData.defaultHashTag()
+                .withId(1L)
+                .build();
+
+        return MissionTestData.defaultMission()
+                .withId(1L)
+                .withHashTags(List.of(hashTag))
+                .build();
     }
 }

--- a/backend/src/test/java/develup/api/SolutionApiTest.java
+++ b/backend/src/test/java/develup/api/SolutionApiTest.java
@@ -47,8 +47,8 @@ class SolutionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data[0].title", equalTo("루터회관 흡연단속 제출합니다.")))
                 .andExpect(jsonPath("$.data[0].thumbnail", equalTo("https://thumbnail.com/1.png")))
                 .andExpect(jsonPath("$.data[0].description", equalTo("안녕하세요. 피드백 잘 부탁 드려요.")))
-                .andExpect(jsonPath("$.data[0].hashTag[0].id", is(1)))
-                .andExpect(jsonPath("$.data[0].hashTag[0].name", equalTo("JAVA")))
+                .andExpect(jsonPath("$.data[0].hashTags[0].id", is(1)))
+                .andExpect(jsonPath("$.data[0].hashTags[0].name", equalTo("JAVA")))
                 .andExpect(jsonPath("$.data.length()", is(2)));
     }
 

--- a/backend/src/test/java/develup/domain/mission/MissionHashTagsTest.java
+++ b/backend/src/test/java/develup/domain/mission/MissionHashTagsTest.java
@@ -1,0 +1,78 @@
+package develup.domain.mission;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Collections;
+import java.util.List;
+import develup.api.exception.DevelupException;
+import develup.domain.hashtag.HashTag;
+import develup.support.data.HashTagTestData;
+import develup.support.data.MissionTestData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MissionHashTagsTest {
+
+    @Test
+    @DisplayName("중복된 해시태그로 생성할 수 없다.")
+    void cantCreateWithDuplicatedHashTags() {
+        HashTag java = HashTagTestData.defaultHashTag()
+                .withId(1L)
+                .withName("JAVA")
+                .build();
+        List<HashTag> duplicatedHashTags = List.of(java, java);
+        Mission mission = MissionTestData.defaultMission().build();
+
+        assertThatThrownBy(() -> new MissionHashTags(mission, duplicatedHashTags))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("중복된 해시태그입니다.");
+    }
+
+    @Test
+    @DisplayName("해시 태깅을 할 수 있다.")
+    void addAll() {
+        List<HashTag> tags = List.of(
+                HashTagTestData.defaultHashTag().withName("JAVA").build(),
+                HashTagTestData.defaultHashTag().withName("JAVASCRIPT").build()
+        );
+        Mission mission = MissionTestData.defaultMission().build();
+        MissionHashTags missionHashTags = new MissionHashTags(mission, Collections.emptyList());
+
+        missionHashTags.addAll(mission, tags);
+
+        assertThat(missionHashTags.getHashTags()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("중복으로 들어온 해시태그를 등록할 수 없다.")
+    void duplicatedTag() {
+        HashTag java = HashTagTestData.defaultHashTag()
+                .withId(1L)
+                .withName("JAVA")
+                .build();
+        List<HashTag> duplicatedHashTags = List.of(java, java);
+        Mission mission = MissionTestData.defaultMission().build();
+        MissionHashTags missionHashTags = new MissionHashTags(mission, Collections.emptyList());
+
+        assertThatThrownBy(() -> missionHashTags.addAll(mission, duplicatedHashTags))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("중복된 해시태그입니다.");
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 태그는 등록할 수 없다.")
+    void alreadyExistTag() {
+        HashTag java = HashTagTestData.defaultHashTag()
+                .withId(1L)
+                .withName("JAVA")
+                .build();
+        Mission mission = MissionTestData.defaultMission().build();
+        MissionHashTags missionHashTags = new MissionHashTags(mission, Collections.emptyList());
+        missionHashTags.addAll(mission, List.of(java));
+
+        assertThatThrownBy(() -> missionHashTags.addAll(mission, List.of(java)))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("중복된 해시태그입니다.");
+    }
+}

--- a/backend/src/test/java/develup/domain/mission/MissionRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/mission/MissionRepositoryTest.java
@@ -43,4 +43,21 @@ class MissionRepositoryTest extends IntegrationTestSupport {
                 () -> assertThat(noneTaggedFound).isEmpty()
         );
     }
+
+    @Test
+    @DisplayName("해시태그가 존재하는 모든 미션을 조회한다.")
+    void findAllHashTaggedMission() {
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
+        Mission mission1 = MissionTestData.defaultMission()
+                .withHashTags(List.of(hashTag))
+                .build();
+        Mission mission2 = MissionTestData.defaultMission()
+                .withHashTags(List.of(hashTag))
+                .build();
+        missionRepository.saveAll(List.of(mission1, mission2));
+
+        List<Mission> missions = missionRepository.findAllHashTaggedMission();
+
+        assertThat(missions).hasSize(2);
+    }
 }

--- a/backend/src/test/java/develup/domain/mission/MissionRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/mission/MissionRepositoryTest.java
@@ -1,0 +1,46 @@
+package develup.domain.mission;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import develup.domain.hashtag.HashTag;
+import develup.domain.hashtag.HashTagRepository;
+import develup.support.IntegrationTestSupport;
+import develup.support.data.HashTagTestData;
+import develup.support.data.MissionTestData;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class MissionRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Autowired
+    private HashTagRepository hashTagRepository;
+
+    @Test
+    @DisplayName("주어진 식별자에 해당하고, 해시태그가 존재하는 미션을 찾는다. ")
+    void findHashTaggedMissionById() {
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
+        Mission hashTaggedMission = MissionTestData.defaultMission()
+                .withHashTags(List.of(hashTag))
+                .build();
+        Mission nonTaggedMission = MissionTestData.defaultMission().build();
+        missionRepository.saveAll(List.of(hashTaggedMission, nonTaggedMission));
+
+        Optional<Mission> hashTaggedFound = missionRepository.findWithHashTagsById(hashTaggedMission.getId());
+        Optional<Mission> noneTaggedFound = missionRepository.findWithHashTagsById(nonTaggedMission.getId());
+
+        Assertions.assertAll(
+                () -> assertThat(hashTaggedFound)
+                        .isPresent()
+                        .map(it -> it.getHashTags().size())
+                        .hasValue(1),
+                () -> assertThat(noneTaggedFound).isEmpty()
+        );
+    }
+}

--- a/backend/src/test/java/develup/domain/mission/MissionRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/mission/MissionRepositoryTest.java
@@ -32,8 +32,8 @@ class MissionRepositoryTest extends IntegrationTestSupport {
         Mission nonTaggedMission = MissionTestData.defaultMission().build();
         missionRepository.saveAll(List.of(hashTaggedMission, nonTaggedMission));
 
-        Optional<Mission> hashTaggedFound = missionRepository.findWithHashTagsById(hashTaggedMission.getId());
-        Optional<Mission> noneTaggedFound = missionRepository.findWithHashTagsById(nonTaggedMission.getId());
+        Optional<Mission> hashTaggedFound = missionRepository.findHashTaggedMissionById(hashTaggedMission.getId());
+        Optional<Mission> noneTaggedFound = missionRepository.findHashTaggedMissionById(nonTaggedMission.getId());
 
         Assertions.assertAll(
                 () -> assertThat(hashTaggedFound)

--- a/backend/src/test/java/develup/domain/mission/MissionTest.java
+++ b/backend/src/test/java/develup/domain/mission/MissionTest.java
@@ -1,12 +1,7 @@
 package develup.domain.mission;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.List;
-import develup.api.exception.DevelupException;
-import develup.domain.hashtag.HashTag;
-import develup.support.data.HashTagTestData;
 import develup.support.data.MissionTestData;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -25,49 +20,5 @@ class MissionTest {
         String actual = mission.getDescriptionUrl();
 
         assertThat(actual).isEqualTo(expected);
-    }
-
-    @Test
-    @DisplayName("해시 태깅을 할 수 있다.")
-    void tagAll() {
-        List<HashTag> tags = List.of(
-                HashTagTestData.defaultHashTag().withName("JAVA").build(),
-                HashTagTestData.defaultHashTag().withName("JAVASCRIPT").build()
-        );
-        Mission mission = MissionTestData.defaultMission().build();
-
-        mission.tagAll(tags);
-
-        assertThat(mission.getHashTags()).hasSize(2);
-    }
-
-    @Test
-    @DisplayName("중복으로 들어온 해시태그를 등록할 수 없다.")
-    void duplicatedTag() {
-        HashTag java = HashTagTestData.defaultHashTag()
-                .withId(1L)
-                .withName("JAVA")
-                .build();
-        List<HashTag> duplicatedHashTags = List.of(java, java);
-        Mission mission = MissionTestData.defaultMission().build();
-
-        assertThatThrownBy(() -> mission.tagAll(duplicatedHashTags))
-                .isInstanceOf(DevelupException.class)
-                .hasMessage("중복된 해시태그입니다.");
-    }
-
-    @Test
-    @DisplayName("이미 존재하는 태그는 등록할 수 없다.")
-    void alreadyExistTag() {
-        HashTag java = HashTagTestData.defaultHashTag()
-                .withId(1L)
-                .withName("JAVA")
-                .build();
-        Mission mission = MissionTestData.defaultMission().build();
-        mission.tagAll(List.of(java));
-
-        assertThatThrownBy(() -> mission.tagAll(List.of(java)))
-                .isInstanceOf(DevelupException.class)
-                .hasMessage("중복된 해시태그입니다.");
     }
 }

--- a/backend/src/test/java/develup/domain/mission/MissionTest.java
+++ b/backend/src/test/java/develup/domain/mission/MissionTest.java
@@ -1,7 +1,12 @@
 package develup.domain.mission;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
+import develup.api.exception.DevelupException;
+import develup.domain.hashtag.HashTag;
+import develup.support.data.HashTagTestData;
 import develup.support.data.MissionTestData;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,5 +25,49 @@ class MissionTest {
         String actual = mission.getDescriptionUrl();
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("해시 태깅을 할 수 있다.")
+    void tagAll() {
+        List<HashTag> tags = List.of(
+                HashTagTestData.defaultHashTag().withName("JAVA").build(),
+                HashTagTestData.defaultHashTag().withName("JAVASCRIPT").build()
+        );
+        Mission mission = MissionTestData.defaultMission().build();
+
+        mission.tagAll(tags);
+
+        assertThat(mission.getHashTags()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("중복으로 들어온 해시태그를 등록할 수 없다.")
+    void duplicatedTag() {
+        HashTag java = HashTagTestData.defaultHashTag()
+                .withId(1L)
+                .withName("JAVA")
+                .build();
+        List<HashTag> duplicatedHashTags = List.of(java, java);
+        Mission mission = MissionTestData.defaultMission().build();
+
+        assertThatThrownBy(() -> mission.tagAll(duplicatedHashTags))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("중복된 해시태그입니다.");
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 태그는 등록할 수 없다.")
+    void alreadyExistTag() {
+        HashTag java = HashTagTestData.defaultHashTag()
+                .withId(1L)
+                .withName("JAVA")
+                .build();
+        Mission mission = MissionTestData.defaultMission().build();
+        mission.tagAll(List.of(java));
+
+        assertThatThrownBy(() -> mission.tagAll(List.of(java)))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("중복된 해시태그입니다.");
     }
 }

--- a/backend/src/test/java/develup/domain/solution/SolutionRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/solution/SolutionRepositoryTest.java
@@ -5,14 +5,18 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
 import java.util.Optional;
+import develup.domain.hashtag.HashTag;
+import develup.domain.hashtag.HashTagRepository;
 import develup.domain.member.Member;
 import develup.domain.member.MemberRepository;
 import develup.domain.mission.Mission;
 import develup.domain.mission.MissionRepository;
 import develup.support.IntegrationTestSupport;
+import develup.support.data.HashTagTestData;
 import develup.support.data.MemberTestData;
 import develup.support.data.MissionTestData;
 import develup.support.data.SolutionTestData;
+import jakarta.persistence.EntityManagerFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +31,12 @@ class SolutionRepositoryTest extends IntegrationTestSupport {
 
     @Autowired
     private MissionRepository missionRepository;
+
+    @Autowired
+    private HashTagRepository hashTagRepository;
+
+    @Autowired
+    private EntityManagerFactory factory;
 
     @Test
     @DisplayName("멤버 식별자와 미션 식별자와 특정 상태에 해당하는 솔루션이 존재하는지 확인한다. ")
@@ -61,13 +71,12 @@ class SolutionRepositoryTest extends IntegrationTestSupport {
     }
 
     @Test
-    @DisplayName("완료된 솔루션 요약 데이터를 조회할 수 있다.")
-    void findCompletedSummaries() {
+    @DisplayName("완료된 솔루션을 조회할 수 있다.")
+    void findAllCompletedSolution() {
         createSolution(SolutionStatus.COMPLETED);
         createSolution(SolutionStatus.COMPLETED);
-        createSolution(SolutionStatus.IN_PROGRESS);
 
-        List<SolutionSummary> actual = solutionRepository.findCompletedSummaries();
+        List<Solution> actual = solutionRepository.findAllCompletedSolution();
 
         assertThat(actual).hasSize(2);
     }
@@ -144,8 +153,10 @@ class SolutionRepositoryTest extends IntegrationTestSupport {
     }
 
     private void createSolution(SolutionStatus status) {
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("A").build());
         Member member = memberRepository.save(MemberTestData.defaultMember().build());
-        Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
+        Mission mission = MissionTestData.defaultMission().withHashTags(List.of(hashTag)).build();
+        missionRepository.save(mission);
 
         Solution solution = SolutionTestData.defaultSolution()
                 .withMember(member)

--- a/backend/src/test/java/develup/domain/solution/SolutionRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/solution/SolutionRepositoryTest.java
@@ -75,6 +75,7 @@ class SolutionRepositoryTest extends IntegrationTestSupport {
     void findAllCompletedSolution() {
         createSolution(SolutionStatus.COMPLETED);
         createSolution(SolutionStatus.COMPLETED);
+        createSolution(SolutionStatus.IN_PROGRESS);
 
         List<Solution> actual = solutionRepository.findAllCompletedSolution();
 

--- a/backend/src/test/java/develup/domain/solution/SolutionRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/solution/SolutionRepositoryTest.java
@@ -16,7 +16,6 @@ import develup.support.data.HashTagTestData;
 import develup.support.data.MemberTestData;
 import develup.support.data.MissionTestData;
 import develup.support.data.SolutionTestData;
-import jakarta.persistence.EntityManagerFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,9 +33,6 @@ class SolutionRepositoryTest extends IntegrationTestSupport {
 
     @Autowired
     private HashTagRepository hashTagRepository;
-
-    @Autowired
-    private EntityManagerFactory factory;
 
     @Test
     @DisplayName("멤버 식별자와 미션 식별자와 특정 상태에 해당하는 솔루션이 존재하는지 확인한다. ")

--- a/backend/src/test/java/develup/support/data/HashTagTestData.java
+++ b/backend/src/test/java/develup/support/data/HashTagTestData.java
@@ -1,0 +1,30 @@
+package develup.support.data;
+
+import develup.domain.hashtag.HashTag;
+
+public class HashTagTestData {
+
+    public static HashTagBuilder defaultHashTag() {
+        return new HashTagBuilder().withName("JAVA");
+    }
+
+    public static class HashTagBuilder {
+
+        private Long id;
+        private String name;
+
+        public HashTagBuilder withId(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public HashTagBuilder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public HashTag build() {
+            return new HashTag(id, name);
+        }
+    }
+}

--- a/backend/src/test/java/develup/support/data/MissionTestData.java
+++ b/backend/src/test/java/develup/support/data/MissionTestData.java
@@ -1,5 +1,8 @@
 package develup.support.data;
 
+import java.util.Collections;
+import java.util.List;
+import develup.domain.hashtag.HashTag;
 import develup.domain.mission.Mission;
 
 public class MissionTestData {
@@ -9,7 +12,8 @@ public class MissionTestData {
                 .withTitle("루터회관 흡연단속")
                 .withThumbnail("https://thumbnail.com/1.png")
                 .withSummary("담배피다 걸린 행성이를 위한 벌금 계산 미션")
-                .withUrl("https://github.com/develup-mission/java-smoking");
+                .withUrl("https://github.com/develup-mission/java-smoking")
+                .withHashTags(Collections.emptyList());
     }
 
     public static class MissionBuilder {
@@ -19,6 +23,7 @@ public class MissionTestData {
         private String thumbnail;
         private String summary;
         private String url;
+        private List<HashTag> hashTags;
 
         public MissionBuilder withId(Long id) {
             this.id = id;
@@ -45,13 +50,19 @@ public class MissionTestData {
             return this;
         }
 
+        public MissionBuilder withHashTags(List<HashTag> hashTags) {
+            this.hashTags = hashTags;
+            return this;
+        }
+
         public Mission build() {
             return new Mission(
                     id,
                     title,
                     thumbnail,
                     summary,
-                    url
+                    url,
+                    hashTags
             );
         }
     }


### PR DESCRIPTION
#### 구현 요약

해시태깅 기능을 구현하고, 미션 목록, 미션 단건, 솔루션 목록(SummarizedSolutionResponse 사용) API에서 태그를 보여주도록 변경했어요. 어색한 부분이나 제가 놓치고 있는 부분이 있다면 피드백 부탁 드립니다. 


#### 연관 이슈

- close #273

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
