### PR TITLE
깃허브 로그인 플로우를 개선 (Issue #298)

### DIFF
--- a/backend/src/main/java/develup/application/auth/OAuthUserInfo.java
+++ b/backend/src/main/java/develup/application/auth/OAuthUserInfo.java
@@ -12,6 +12,12 @@ public record OAuthUserInfo(
         String name
 ) {
 
+    public OAuthUserInfo {
+        if (name == null || name.isBlank()) {
+            name = login;
+        }
+    }
+
     public Member toMember(Provider provider) {
         return new Member(
                 email,

--- a/backend/src/main/java/develup/infra/auth/github/GithubUserInfo.java
+++ b/backend/src/main/java/develup/infra/auth/github/GithubUserInfo.java
@@ -11,7 +11,7 @@ public record GithubUserInfo(
         String login,
         String avatarUrl,
         @Nullable String email,
-        String name
+        @Nullable String name
 ) {
 
     public OAuthUserInfo toOAuthUserInfo() {


### PR DESCRIPTION
#### 구현 요약

깃허브 로그인 할 때 **깃허브에서 이름 정보를 가져 올 수 없는 경우 login(아이디) 정보를 이름으로 해석**합니다.

이런 결정을 한 이유는 이름이 사용자가 불리고 싶은 것이라 생각해 이름을 우선적으로 사용하되, 없으면 식별자인 아이디를 사용하도록 했습니다.

#### 연관 이슈

- close #298

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
