### PR TITLE
백엔드 Nginx, Spring docker 컨테이너로 띄우기 (issue #282)

### DIFF
--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -20,6 +20,7 @@ services:
     ports:
       - "8080:8080"
     environment:
+      TZ: "Asia/Seoul"
       SPRING_PROFILE: dev
     restart: always
     container_name: develup-app

--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -1,0 +1,28 @@
+services:
+  nginx:
+    image: nginx
+    depends_on:
+      - application
+    networks:
+      - nginx-app-net
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - /home/ubuntu/custom.conf:/etc/nginx/conf.d/custom.conf
+      - /etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem:/etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem
+      - /etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem:/etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem
+
+  application:
+    image: ${BACKEND_APP_IMAGE_NAME}
+    networks:
+      - nginx-app-net
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_PROFILE: dev
+    restart: always
+    container_name: develup-app
+
+networks:
+  nginx-app-net:

--- a/backend/src/Dockerfile
+++ b/backend/src/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:21
+
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-Dspring.profiles.active=${SPRING_PROFILE}", \
+                "-jar", "/app.jar"]


### PR DESCRIPTION
#### 구현 요약

- 해당 PR은 우선 dev 레파지토리에 올라갑니다.

백엔드 Nginx와 Spring을 도커 컨테이너로 띄우기 위한 파일들을 추가했습니다.
현재 https://dev.api.devel-up.co.kr/ 이 주소에서 도커로 실행 중에 있으니 참고해주세요. 👍

#### 연관 이슈

- close #282

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
