### PR TITLE
JPA 추상 클래스 적용 (issue #304)

### DIFF
--- a/backend/src/main/java/develup/domain/IdentifiableEntity.java
+++ b/backend/src/main/java/develup/domain/IdentifiableEntity.java
@@ -35,7 +35,7 @@ public abstract class IdentifiableEntity {
             return false;
         }
         IdentifiableEntity that = (IdentifiableEntity) o;
-        return Objects.equals(getId(), that.getId());
+        return this.getId() != null && Objects.equals(getId(), that.getId());
     }
 
     @Override

--- a/backend/src/main/java/develup/domain/hashtag/HashTag.java
+++ b/backend/src/main/java/develup/domain/hashtag/HashTag.java
@@ -1,18 +1,11 @@
 package develup.domain.hashtag;
 
-import java.util.Objects;
+import develup.domain.IdentifiableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 
 @Entity
-public class HashTag {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class HashTag extends IdentifiableEntity {
 
     @Column(nullable = false)
     private String name;
@@ -25,32 +18,11 @@ public class HashTag {
     }
 
     public HashTag(Long id, String name) {
-        this.id = id;
+        super(id);
         this.name = name;
-    }
-
-    public Long getId() {
-        return id;
     }
 
     public String getName() {
         return name;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof HashTag hashTag)) {
-            return false;
-        }
-
-        return this.getId() != null && Objects.equals(getId(), hashTag.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getId());
     }
 }

--- a/backend/src/main/java/develup/domain/member/Member.java
+++ b/backend/src/main/java/develup/domain/member/Member.java
@@ -1,20 +1,13 @@
 package develup.domain.member;
 
-import java.util.Objects;
+import develup.domain.CreatedAtAuditableEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 
 @Entity
-public class Member {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Member extends CreatedAtAuditableEntity {
 
     @Column
     private String email;
@@ -40,16 +33,13 @@ public class Member {
     }
 
     public Member(Long id, String email, Provider provider, Long socialId, String name, String imageUrl) {
+        super(id);
         this.id = id;
         this.email = email;
         this.provider = provider;
         this.socialId = socialId;
         this.name = name;
         this.imageUrl = imageUrl;
-    }
-
-    public Long getId() {
-        return id;
     }
 
     public String getEmail() {
@@ -70,22 +60,5 @@ public class Member {
 
     public String getImageUrl() {
         return imageUrl;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof Member member)) {
-            return false;
-        }
-
-        return this.getId() != null && Objects.equals(getId(), member.getId());
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getId());
     }
 }

--- a/backend/src/main/java/develup/domain/mission/Mission.java
+++ b/backend/src/main/java/develup/domain/mission/Mission.java
@@ -2,23 +2,17 @@ package develup.domain.mission;
 
 import java.util.List;
 import java.util.Set;
+import develup.domain.IdentifiableEntity;
 import develup.domain.hashtag.HashTag;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 
 @Entity
-public class Mission {
+public class Mission extends IdentifiableEntity {
 
     private static final String DESCRIPTION_BASE_URL_PREFIX = "https://raw.githubusercontent.com/develup-mission/";
     private static final String DESCRIPTION_BASE_URL_SUFFIX = "/main/README.md";
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
 
     @Column(nullable = false)
     private String title;
@@ -43,7 +37,7 @@ public class Mission {
     }
 
     public Mission(Long id, String title, String thumbnail, String summary, String url, List<HashTag> hashTags) {
-        this.id = id;
+        super(id);
         this.title = title;
         this.thumbnail = thumbnail;
         this.summary = summary;
@@ -59,10 +53,6 @@ public class Mission {
         String[] split = url.split("/");
 
         return DESCRIPTION_BASE_URL_PREFIX + split[split.length - 1] + DESCRIPTION_BASE_URL_SUFFIX;
-    }
-
-    public Long getId() {
-        return id;
     }
 
     public String getTitle() {

--- a/backend/src/main/java/develup/domain/mission/MissionHashTag.java
+++ b/backend/src/main/java/develup/domain/mission/MissionHashTag.java
@@ -1,20 +1,14 @@
 package develup.domain.mission;
 
+import develup.domain.IdentifiableEntity;
 import develup.domain.hashtag.HashTag;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
 @Entity
-public class MissionHashTag {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class MissionHashTag extends IdentifiableEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(nullable = false)
@@ -32,13 +26,9 @@ public class MissionHashTag {
     }
 
     public MissionHashTag(Long id, Mission mission, HashTag hashTag) {
-        this.id = id;
+        super(id);
         this.mission = mission;
         this.hashTag = hashTag;
-    }
-
-    public Long getId() {
-        return id;
     }
 
     public Mission getMission() {

--- a/backend/src/main/java/develup/domain/solution/Solution.java
+++ b/backend/src/main/java/develup/domain/solution/Solution.java
@@ -19,12 +19,12 @@ import jakarta.persistence.ManyToOne;
 @Entity
 public class Solution extends CreatedAtAuditableEntity {
 
-    @JoinColumn(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
     private Mission mission;
 
-    @JoinColumn(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(nullable = false)
     private Member member;
 
     @Embedded

--- a/backend/src/main/java/develup/domain/solution/Solution.java
+++ b/backend/src/main/java/develup/domain/solution/Solution.java
@@ -3,6 +3,7 @@ package develup.domain.solution;
 import java.util.Set;
 import develup.api.exception.DevelupException;
 import develup.api.exception.ExceptionType;
+import develup.domain.CreatedAtAuditableEntity;
 import develup.domain.member.Member;
 import develup.domain.mission.Mission;
 import develup.domain.mission.MissionHashTag;
@@ -12,18 +13,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
 @Entity
-public class Solution {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Solution extends CreatedAtAuditableEntity {
 
     @JoinColumn(nullable = false)
     @ManyToOne(fetch = FetchType.LAZY)
@@ -69,7 +63,7 @@ public class Solution {
             String url,
             SolutionStatus status
     ) {
-        this.id = id;
+        super(id);
         this.mission = mission;
         this.member = member;
         this.title = title;
@@ -95,10 +89,6 @@ public class Solution {
 
     public boolean isInProgress() {
         return status.isInProgress();
-    }
-
-    public Long getId() {
-        return id;
     }
 
     public Mission getMission() {

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,48 +1,46 @@
-INSERT INTO member (email, provider, social_id, name, image_url)
-VALUES ('test1@gmail.com', 'GITHUB', '1234', '구름', 'www.naver.com');
-
-INSERT INTO member (email, provider, social_id, name, image_url)
-VALUES ('test1@gmail.com', 'GITHUB', '1234', '리브', 'www.naver.com');
-
-INSERT INTO member (email, provider, social_id, name, image_url)
-VALUES ('test1@gmail.com', 'GITHUB', '1234', '아톰', 'www.naver.com');
+INSERT INTO member (email, provider, social_id, name, image_url, created_at)
+VALUES ('test1@gmail.com', 'GITHUB', '1234', '구름', 'www.naver.com', '2024-08-16 13:40:00'),
+       ('test1@gmail.com', 'GITHUB', '1234', '리브', 'www.naver.com', '2024-08-16 13:40:00'),
+       ('test1@gmail.com', 'GITHUB', '1234', '아톰', 'www.naver.com', '2024-08-16 13:40:00');
 
 INSERT INTO mission (title, thumbnail, summary, url)
 VALUES ('루터회관 흡연 단속', 'https://raw.githubusercontent.com/develup-mission/docs/main/image/java-smoking.png',
-        '담배피다 걸린 행성이를 위한 벌금 계산 미션', 'https://github.com/develup-mission/java-smoking');
-INSERT INTO mission (title, thumbnail, summary, url)
-VALUES ('숫자 맞추기 게임', 'https://raw.githubusercontent.com/develup-mission/docs/main/image/java-guessing-number.png',
+        '담배피다 걸린 행성이를 위한 벌금 계산 미션', 'https://github.com/develup-mission/java-smoking'),
+       ('숫자 맞추기 게임', 'https://raw.githubusercontent.com/develup-mission/docs/main/image/java-guessing-number.png',
         '숫자를 맞춰보자', 'https://github.com/develup-mission/java-guessing-number');
 
-INSERT INTO hash_tag (name) VALUES ('JAVA');
-INSERT INTO hash_tag (name) VALUES ('객체지향');
-INSERT INTO hash_tag (name) VALUES ('TDD');
-INSERT INTO hash_tag (name) VALUES ('클린코드');
-INSERT INTO hash_tag (name) VALUES ('레벨1');
+INSERT INTO hash_tag (name)
+VALUES ('JAVA'),
+       ('객체지향'),
+       ('TDD'),
+       ('클린코드'),
+       ('레벨1');
 
-INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (1, 1);
-INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (1, 2);
-INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (1, 3);
-INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (1, 4);
-INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (1, 5);
-INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (2, 1);
-INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (2, 2);
-INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (2, 3);
-INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (2, 4);
-INSERT INTO mission_hash_tag (mission_id, hash_tag_id) VALUES (2, 5);
+INSERT INTO mission_hash_tag (mission_id, hash_tag_id)
+VALUES (1, 1),
+       (1, 2),
+       (1, 3),
+       (1, 4),
+       (1, 5),
+       (2, 1),
+       (2, 2),
+       (2, 3),
+       (2, 4),
+       (2, 5);
 
-INSERT INTO solution (mission_id, member_id, title, description, url, status)
-VALUES (1, 1, '릴리 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED');
-INSERT INTO solution (mission_id, member_id, title, description, url, status)
-VALUES (1, 2, '아톰 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED');
-INSERT INTO solution (mission_id, member_id, title, description, url, status)
-VALUES (1, 3, '라이언 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED');
-INSERT INTO solution (mission_id, member_id, title, description, url, status)
-VALUES (2, 1, '아톰 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED');
-INSERT INTO solution (mission_id, member_id, title, description, url, status)
-VALUES (2, 2, '릴리 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED');
-INSERT INTO solution (mission_id, member_id, title, description, url, status)
-VALUES (2, 3, '아톰 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED');
+INSERT INTO solution (mission_id, member_id, title, description, url, status, created_at)
+VALUES (1, 1, '릴리 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED',
+        '2024-08-16 13:40:00'),
+       (1, 2, '아톰 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED',
+        '2024-08-16 13:40:00'),
+       (1, 3, '라이언 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED',
+        '2024-08-16 13:40:00'),
+       (2, 1, '아톰 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED',
+        '2024-08-16 13:40:00'),
+       (2, 2, '릴리 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED',
+        '2024-08-16 13:40:00'),
+       (2, 3, '아톰 미션 제출합니다.', '안녕하세요. 잘 부탁 드립니다.', 'https://github.com/develup/mission/pull/1', 'COMPLETED',
+        '2024-08-16 13:40:00');
 
 -- root-1
 -- ㄴ root-1-1
@@ -52,16 +50,10 @@ VALUES (2, 3, '아톰 미션 제출합니다.', '안녕하세요. 잘 부탁 드
 -- ㄴ root-2-2 (deleted, view x)
 -- root-3 (deleted, view x)
 INSERT INTO solution_comment (solution_id, member_id, content, parent_comment_id, deleted_at, created_at)
-VALUES (1, 1, '1', NULL, NULL, '2021-08-01 00:00:00');
-INSERT INTO solution_comment (solution_id, member_id, content, parent_comment_id, deleted_at, created_at)
-VALUES (1, 1, '2', NULL, '2021-08-01 00:00:00', '2021-08-01 00:00:00');
-INSERT INTO solution_comment (solution_id, member_id, content, parent_comment_id, deleted_at, created_at)
-VALUES (1, 1, '3', NULL, '2021-08-01 00:00:00', '2021-08-01 00:00:00');
-INSERT INTO solution_comment (solution_id, member_id, content, parent_comment_id, deleted_at, created_at)
-VALUES (1, 1, '2-1', 2, NULL, '2021-08-01 00:00:00');
-INSERT INTO solution_comment (solution_id, member_id, content, parent_comment_id, deleted_at, created_at)
-VALUES (1, 1, '1-1', 1, NULL, '2021-08-01 00:00:00');
-INSERT INTO solution_comment (solution_id, member_id, content, parent_comment_id, deleted_at, created_at)
-VALUES (1, 1, '2-2', 2, '2021-08-01 00:00:00', '2021-08-01 00:00:00');
-INSERT INTO solution_comment (solution_id, member_id, content, parent_comment_id, deleted_at, created_at)
-VALUES (1, 1, '1-2', 1, NULL, '2021-08-01 00:00:00');
+VALUES (1, 1, '1', NULL, NULL, '2024-08-16 13:40:00'),
+       (1, 1, '2', NULL, '2024-08-12 13:40:00', '2024-08-16 13:40:00'),
+       (1, 1, '3', NULL, '2024-08-12 13:40:00', '2024-08-16 13:40:00'),
+       (1, 1, '2-1', 2, NULL, '2024-08-16 13:40:00'),
+       (1, 1, '1-1', 1, NULL, '2024-08-16 13:40:00'),
+       (1, 1, '2-2', 2, '2024-08-12 13:40:00', '2024-08-16 13:40:00'),
+       (1, 1, '1-2', 1, NULL, '2024-08-16 13:40:00');

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -1,7 +1,10 @@
 INSERT INTO member (email, provider, social_id, name, image_url, created_at)
-VALUES ('test1@gmail.com', 'GITHUB', '1234', '구름', 'www.naver.com', '2024-08-16 13:40:00'),
-       ('test1@gmail.com', 'GITHUB', '1234', '리브', 'www.naver.com', '2024-08-16 13:40:00'),
-       ('test1@gmail.com', 'GITHUB', '1234', '아톰', 'www.naver.com', '2024-08-16 13:40:00');
+VALUES ('test1@gmail.com', 'GITHUB', '1234', '구름', 'https://avatars.githubusercontent.com/u/75781414?v=4',
+        '2024-08-16 13:40:00'),
+       ('test1@gmail.com', 'GITHUB', '1234', '리브', 'https://avatars.githubusercontent.com/u/131349867?v=4',
+        '2024-08-16 13:40:00'),
+       ('test1@gmail.com', 'GITHUB', '1234', '아톰', 'https://avatars.githubusercontent.com/u/39932141?v=4',
+        '2024-08-16 13:40:00');
 
 INSERT INTO mission (title, thumbnail, summary, url)
 VALUES ('루터회관 흡연 단속', 'https://raw.githubusercontent.com/develup-mission/docs/main/image/java-smoking.png',


### PR DESCRIPTION
#### 구현 요약

댓글 API 구현 PR에 있던 jpa 추상 클래스 IdentifiableEntity, CreatedAtAuditingEntity를 다른 엔티티에 적용했습니다.
IdentifiableEntity는 HashTag, Mission, MissionHashTag에 적용했습니다.
CreatedAtAuditingEntity(생성 시간)는 IdentifiableEntity를 상속받고 있고, Member, Solution, SolutionComment에 적용했습니다.

IdentifiableEntity, CreatedAtAuditingEntity를 사용할 때 주의할 점은 주 생성자에 id를 super(id)로 해주어야 합니다.

#### 연관 이슈

- https://github.com/woowacourse-teams/2024-devel-up/pull/292

- close #304 

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
