### PR TITLE
풀이 댓글 수정 구현 (issue #419)

### DIFF
--- a/backend/src/main/java/develup/api/SolutionCommentApi.java
+++ b/backend/src/main/java/develup/api/SolutionCommentApi.java
@@ -10,12 +10,15 @@ import develup.application.solution.comment.MySolutionCommentResponse;
 import develup.application.solution.comment.SolutionCommentRepliesResponse;
 import develup.application.solution.comment.SolutionCommentRequest;
 import develup.application.solution.comment.SolutionCommentService;
+import develup.application.solution.comment.UpdateSolutionCommentRequest;
+import develup.application.solution.comment.UpdateSolutionCommentResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -60,6 +63,18 @@ public class SolutionCommentApi {
         URI location = URI.create("/solutions/" + response.solutionId() + "/comments/" + response.id());
 
         return ResponseEntity.created(location).body(new ApiResponse<>(response));
+    }
+
+    @PatchMapping("/solutions/comments/{commentId}")
+    @Operation(summary = "솔루션 댓글 수정 API", description = "솔루션의 댓글을 수정합니다.")
+    public ResponseEntity<ApiResponse<UpdateSolutionCommentResponse>> updateComment(
+            @PathVariable Long commentId,
+            @Valid @RequestBody UpdateSolutionCommentRequest request,
+            @Auth Accessor accessor
+    ) {
+        UpdateSolutionCommentResponse response = solutionCommentService.updateComment(commentId, request, accessor.id());
+
+        return ResponseEntity.ok(new ApiResponse<>(response));
     }
 
     @DeleteMapping("/solutions/comments/{commentId}")

--- a/backend/src/main/java/develup/api/exception/ExceptionType.java
+++ b/backend/src/main/java/develup/api/exception/ExceptionType.java
@@ -20,7 +20,7 @@ public enum ExceptionType {
     COMMENT_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "이미 삭제된 댓글입니다."),
     CANNOT_REPLY_TO_REPLY(HttpStatus.BAD_REQUEST, "답글에는 답글을 작성할 수 없습니다."),
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
-    COMMENT_NOT_WRITTEN_BY_MEMBER(HttpStatus.FORBIDDEN, "작성자만 댓글을 삭제할 수 있습니다."),
+    COMMENT_NOT_WRITTEN_BY_MEMBER(HttpStatus.FORBIDDEN, "댓글 작성자가 아닙니다."),
     DUPLICATED_HASHTAG(HttpStatus.BAD_REQUEST, "중복된 해시태그입니다."),
 
     ;

--- a/backend/src/main/java/develup/application/solution/comment/SolutionCommentService.java
+++ b/backend/src/main/java/develup/application/solution/comment/SolutionCommentService.java
@@ -86,6 +86,17 @@ public class SolutionCommentService {
         return solutionCommentRepository.save(rootComment);
     }
 
+    public UpdateSolutionCommentResponse updateComment(Long commentId, UpdateSolutionCommentRequest request, Long id) {
+        SolutionComment comment = getComment(commentId);
+        if (comment.isNotWrittenBy(id)) {
+            throw new DevelupException(ExceptionType.COMMENT_NOT_WRITTEN_BY_MEMBER);
+        }
+
+        comment.updateContent(request.content());
+
+        return UpdateSolutionCommentResponse.from(comment);
+    }
+
     public void deleteComment(Long commentId, Long memberId) {
         SolutionComment comment = getComment(commentId);
 

--- a/backend/src/main/java/develup/application/solution/comment/UpdateSolutionCommentRequest.java
+++ b/backend/src/main/java/develup/application/solution/comment/UpdateSolutionCommentRequest.java
@@ -1,0 +1,8 @@
+package develup.application.solution.comment;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateSolutionCommentRequest(
+        @NotBlank String content
+) {
+}

--- a/backend/src/main/java/develup/application/solution/comment/UpdateSolutionCommentResponse.java
+++ b/backend/src/main/java/develup/application/solution/comment/UpdateSolutionCommentResponse.java
@@ -1,0 +1,24 @@
+package develup.application.solution.comment;
+
+import java.time.LocalDateTime;
+import develup.application.member.MemberResponse;
+import develup.domain.solution.comment.SolutionComment;
+
+public record UpdateSolutionCommentResponse(
+        Long id,
+        Long solutionId,
+        String content,
+        MemberResponse member,
+        LocalDateTime createdAt
+) {
+
+    public static UpdateSolutionCommentResponse from(SolutionComment comment) {
+        return new UpdateSolutionCommentResponse(
+                comment.getId(),
+                comment.getSolutionId(),
+                comment.getContent(),
+                MemberResponse.from(comment.getMember()),
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/develup/domain/solution/comment/SolutionComment.java
+++ b/backend/src/main/java/develup/domain/solution/comment/SolutionComment.java
@@ -84,6 +84,14 @@ public class SolutionComment extends CreatedAtAuditableEntity {
         return reply;
     }
 
+    public void updateContent(String content) {
+        if (this.isDeleted()) {
+            throw new DevelupException(ExceptionType.COMMENT_ALREADY_DELETED);
+        }
+
+        this.content = content;
+    }
+
     public void delete() {
         if (this.isDeleted()) {
             throw new DevelupException(ExceptionType.COMMENT_ALREADY_DELETED);

--- a/backend/src/test/java/develup/api/SolutionCommentApiTest.java
+++ b/backend/src/test/java/develup/api/SolutionCommentApiTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -18,6 +19,8 @@ import develup.application.solution.comment.MySolutionCommentResponse;
 import develup.application.solution.comment.SolutionCommentRepliesResponse;
 import develup.application.solution.comment.SolutionCommentRequest;
 import develup.application.solution.comment.SolutionReplyResponse;
+import develup.application.solution.comment.UpdateSolutionCommentRequest;
+import develup.application.solution.comment.UpdateSolutionCommentResponse;
 import develup.domain.member.Member;
 import develup.support.data.MemberTestData;
 import jakarta.servlet.http.Cookie;
@@ -98,6 +101,37 @@ class SolutionCommentApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.parentCommentId", equalTo(null)))
                 .andExpect(jsonPath("$.data.member.id", equalTo(1)))
                 .andExpect(jsonPath("$.data.createdAt").exists());
+    }
+
+    @Test
+    @DisplayName("댓글 내용을 수정한다.")
+    void updateComment() throws Exception {
+        Member member = MemberTestData.defaultMember().withId(1L).build();
+        MemberResponse memberResponse = MemberResponse.from(member);
+        UpdateSolutionCommentRequest request = new UpdateSolutionCommentRequest("updated content");
+        UpdateSolutionCommentResponse response = new UpdateSolutionCommentResponse(
+                1L,
+                1L,
+                "updated content",
+                memberResponse,
+                LocalDateTime.now()
+        );
+
+        BDDMockito.given(solutionCommentService.updateComment(any(), any(), any()))
+                .willReturn(response);
+
+        mockMvc.perform(
+                        patch("/solutions/comments/1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id", equalTo(1)))
+                .andExpect(jsonPath("$.data.solutionId", equalTo(1)))
+                .andExpect(jsonPath("$.data.member.id", equalTo(1)))
+                .andExpect(jsonPath("$.data.createdAt").exists())
+                .andExpect(jsonPath("$.data.content", equalTo("updated content")));
     }
 
     @Test

--- a/backend/src/test/java/develup/domain/solution/comment/SolutionCommentTest.java
+++ b/backend/src/test/java/develup/domain/solution/comment/SolutionCommentTest.java
@@ -30,6 +30,31 @@ class SolutionCommentTest {
     }
 
     @Test
+    @DisplayName("댓글 내용을 수정할 수 있다.")
+    void updateContent() {
+        SolutionComment comment = SolutionCommentTestData.defaultSolutionComment().build();
+        String updatedContent = "수정된 댓글입니다.";
+
+        comment.updateContent(updatedContent);
+
+        assertThat(comment.getContent()).isEqualTo(updatedContent);
+    }
+
+    @Test
+    @DisplayName("삭제된 댓글의 내용을 수정할 수 없다.")
+    void updateContentFailedWhenAlreadyDeleted() {
+        SolutionComment comment = SolutionCommentTestData.defaultSolutionComment()
+                .withDeletedAt(LocalDateTime.now())
+                .build();
+        String updatedContent = "수정된 댓글입니다.";
+
+        assertThatThrownBy(() -> comment.updateContent(updatedContent))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("이미 삭제된 댓글입니다.");
+    }
+
+
+    @Test
     @DisplayName("댓글을 삭제할 수 있다.")
     void delete() {
         SolutionComment comment = SolutionCommentTestData.defaultSolutionComment().build();


### PR DESCRIPTION
#### 구현 요약

풀이 댓글 수정 구현을 구현했습니다.

- 삭제된 댓글은 수정할 수 없습니다.
- 자신이 작성한 댓글만 수정할 수 있습니다.
- 댓글 수정은 내용(content)만 할 수 있습니다.

참고: ExceptionType의 COMMENT_NOT_WRITTEN_BY_MEMBER의 메세지를 
"작성자만 댓글을 삭제할 수 있습니다." -> "댓글 작성자가 아닙니다." 로 수정했습니다.

#### 연관 이슈

- close #419 

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
