### PR TITLE
디스커션 글쓰기 기능 구현 (issue #437)

### DIFF
--- a/backend/src/main/java/develup/api/DiscussionApi.java
+++ b/backend/src/main/java/develup/api/DiscussionApi.java
@@ -4,9 +4,9 @@ import java.util.List;
 import develup.api.auth.Auth;
 import develup.api.common.ApiResponse;
 import develup.application.auth.Accessor;
+import develup.application.discussion.CreateDiscussionRequest;
 import develup.application.discussion.DiscussionResponse;
 import develup.application.discussion.DiscussionService;
-import develup.application.discussion.SubmitDiscussionRequest;
 import develup.application.discussion.SummarizedDiscussionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -41,11 +41,11 @@ public class DiscussionApi {
 
     @PostMapping("/discussions/submit")
     @Operation(summary = "디스커션 제출 API", description = "디스커션을 제출합니다.")
-    public ResponseEntity<ApiResponse<DiscussionResponse>> submitDiscussion(
+    public ResponseEntity<ApiResponse<DiscussionResponse>> createDiscussion(
             @Auth Accessor accessor,
-            @Valid @RequestBody SubmitDiscussionRequest request
+            @Valid @RequestBody CreateDiscussionRequest request
     ) {
-        DiscussionResponse response = discussionService.submit(accessor.id(), request);
+        DiscussionResponse response = discussionService.create(accessor.id(), request);
 
         return ResponseEntity.ok(new ApiResponse<>(response));
     }

--- a/backend/src/main/java/develup/api/DiscussionApi.java
+++ b/backend/src/main/java/develup/api/DiscussionApi.java
@@ -1,13 +1,20 @@
 package develup.api;
 
 import java.util.List;
+import develup.api.auth.Auth;
 import develup.api.common.ApiResponse;
+import develup.application.auth.Accessor;
+import develup.application.discussion.DiscussionResponse;
 import develup.application.discussion.DiscussionService;
+import develup.application.discussion.SubmitDiscussionRequest;
 import develup.application.discussion.SummarizedDiscussionResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,5 +37,16 @@ public class DiscussionApi {
         List<SummarizedDiscussionResponse> responses = discussionService.getSummaries(mission, hashTag);
 
         return ResponseEntity.ok(new ApiResponse<>(responses));
+    }
+
+    @PostMapping("/discussions/submit")
+    @Operation(summary = "디스커션 제출 API", description = "디스커션을 제출합니다.")
+    public ResponseEntity<ApiResponse<DiscussionResponse>> submitDiscussion(
+            @Auth Accessor accessor,
+            @Valid @RequestBody SubmitDiscussionRequest request
+    ) {
+        DiscussionResponse response = discussionService.submit(accessor.id(), request);
+
+        return ResponseEntity.ok(new ApiResponse<>(response));
     }
 }

--- a/backend/src/main/java/develup/api/exception/ExceptionType.java
+++ b/backend/src/main/java/develup/api/exception/ExceptionType.java
@@ -24,6 +24,7 @@ public enum ExceptionType {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
     COMMENT_NOT_WRITTEN_BY_MEMBER(HttpStatus.FORBIDDEN, "댓글 작성자가 아닙니다."),
     DUPLICATED_HASHTAG(HttpStatus.BAD_REQUEST, "중복된 해시태그입니다."),
+    HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 해시태그입니다."),
 
     ;
 

--- a/backend/src/main/java/develup/application/discussion/CreateDiscussionRequest.java
+++ b/backend/src/main/java/develup/application/discussion/CreateDiscussionRequest.java
@@ -3,7 +3,7 @@ package develup.application.discussion;
 import java.util.List;
 import jakarta.validation.constraints.NotBlank;
 
-public record SubmitDiscussionRequest(
+public record CreateDiscussionRequest(
         @NotBlank String title,
         @NotBlank String content,
         Long missionId,

--- a/backend/src/main/java/develup/application/discussion/CreateDiscussionRequest.java
+++ b/backend/src/main/java/develup/application/discussion/CreateDiscussionRequest.java
@@ -2,11 +2,12 @@ package develup.application.discussion;
 
 import java.util.List;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record CreateDiscussionRequest(
         @NotBlank String title,
         @NotBlank String content,
         Long missionId,
-        List<Long> hashTagIds
+        @NotNull List<Long> hashTagIds
 ) {
 }

--- a/backend/src/main/java/develup/application/discussion/DiscussionResponse.java
+++ b/backend/src/main/java/develup/application/discussion/DiscussionResponse.java
@@ -1,0 +1,49 @@
+package develup.application.discussion;
+
+import java.util.List;
+import develup.application.hashtag.HashTagResponse;
+import develup.application.member.MemberResponse;
+import develup.application.mission.MissionResponse;
+import develup.domain.discussion.Discussion;
+
+public record DiscussionResponse(
+        Long id,
+        MemberResponse member,
+        String title,
+        String content,
+        MissionResponse mission,
+        List<HashTagResponse> hashTags
+) {
+
+    public static DiscussionResponse from(Discussion discussion) {
+        List<HashTagResponse> hashTagResponses = discussion.getHashTags()
+                .stream()
+                .map(HashTagResponse::from)
+                .toList();
+
+        return new DiscussionResponse(
+                discussion.getId(),
+                MemberResponse.from(discussion.getMember()),
+                discussion.getTitle(),
+                discussion.getContent(),
+                MissionResponse.from(discussion.getMission()),
+                hashTagResponses
+        );
+    }
+
+    public static DiscussionResponse createWithoutMission(Discussion discussion) {
+        List<HashTagResponse> hashTagResponses = discussion.getHashTags()
+                .stream()
+                .map(HashTagResponse::from)
+                .toList();
+
+        return new DiscussionResponse(
+                discussion.getId(),
+                MemberResponse.from(discussion.getMember()),
+                discussion.getTitle(),
+                discussion.getContent(),
+                null,
+                hashTagResponses
+        );
+    }
+}

--- a/backend/src/main/java/develup/application/discussion/DiscussionService.java
+++ b/backend/src/main/java/develup/application/discussion/DiscussionService.java
@@ -42,7 +42,7 @@ public class DiscussionService {
                 .toList();
     }
 
-    public DiscussionResponse submit(Long memberId, SubmitDiscussionRequest request) {
+    public DiscussionResponse create(Long memberId, CreateDiscussionRequest request) {
         Mission mission = getMission(request.missionId());
         Member member = getMember(memberId);
         List<HashTag> hashTags = getHashTags(request.hashTagIds());
@@ -61,6 +61,7 @@ public class DiscussionService {
         if (missionId == null) {
             return null;
         }
+
         return missionRepository.findById(missionId)
                 .orElseThrow(() -> new DevelupException(ExceptionType.MISSION_NOT_FOUND));
     }

--- a/backend/src/main/java/develup/application/discussion/DiscussionService.java
+++ b/backend/src/main/java/develup/application/discussion/DiscussionService.java
@@ -72,10 +72,6 @@ public class DiscussionService {
     }
 
     private List<HashTag> getHashTags(List<Long> hashTagIds) {
-        if (hashTagIds == null || hashTagIds.isEmpty()) {
-            return null;
-        }
-
         return hashTagIds.stream()
                 .map(id -> hashTagRepository.findById(id)
                         .orElseThrow(() -> new DevelupException(ExceptionType.HASHTAG_NOT_FOUND)))

--- a/backend/src/main/java/develup/application/discussion/DiscussionService.java
+++ b/backend/src/main/java/develup/application/discussion/DiscussionService.java
@@ -1,7 +1,17 @@
 package develup.application.discussion;
 
 import java.util.List;
+import develup.api.exception.DevelupException;
+import develup.api.exception.ExceptionType;
+import develup.domain.discussion.Discussion;
 import develup.domain.discussion.DiscussionRepository;
+import develup.domain.discussion.Title;
+import develup.domain.hashtag.HashTag;
+import develup.domain.hashtag.HashTagRepository;
+import develup.domain.member.Member;
+import develup.domain.member.MemberRepository;
+import develup.domain.mission.Mission;
+import develup.domain.mission.MissionRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,14 +20,72 @@ import org.springframework.transaction.annotation.Transactional;
 public class DiscussionService {
 
     private final DiscussionRepository discussionRepository;
+    private final MemberRepository memberRepository;
+    private final MissionRepository missionRepository;
+    private final HashTagRepository hashTagRepository;
 
-    public DiscussionService(DiscussionRepository discussionRepository) {
+    public DiscussionService(
+            DiscussionRepository discussionRepository,
+            MemberRepository memberRepository,
+            MissionRepository missionRepository,
+            HashTagRepository hashTagRepository
+    ) {
         this.discussionRepository = discussionRepository;
+        this.memberRepository = memberRepository;
+        this.missionRepository = missionRepository;
+        this.hashTagRepository = hashTagRepository;
     }
 
     public List<SummarizedDiscussionResponse> getSummaries(String mission, String hashTagName) {
         return discussionRepository.findByMissionAndHashTagName(mission, hashTagName).stream()
                 .map(SummarizedDiscussionResponse::from)
                 .toList();
+    }
+
+    public DiscussionResponse submit(Long memberId, SubmitDiscussionRequest request) {
+        Mission mission = getMission(request.missionId());
+        Member member = getMember(memberId);
+        List<HashTag> hashTags = getHashTags(request.hashTagIds());
+        Discussion discussion = discussionRepository.save(new Discussion(
+                new Title(request.title()),
+                request.content(),
+                mission,
+                member,
+                hashTags
+        ));
+
+        return createDiscussionResponse(discussion);
+    }
+
+    private Mission getMission(Long missionId) {
+        if (missionId == null) {
+            return null;
+        }
+        return missionRepository.findById(missionId)
+                .orElseThrow(() -> new DevelupException(ExceptionType.MISSION_NOT_FOUND));
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new DevelupException(ExceptionType.MEMBER_NOT_FOUND));
+    }
+
+    private List<HashTag> getHashTags(List<Long> hashTagIds) {
+        if (hashTagIds == null || hashTagIds.isEmpty()) {
+            return null;
+        }
+
+        return hashTagIds.stream()
+                .map(id -> hashTagRepository.findById(id)
+                        .orElseThrow(() -> new DevelupException(ExceptionType.HASHTAG_NOT_FOUND)))
+                .toList();
+    }
+
+    private DiscussionResponse createDiscussionResponse(Discussion discussion) {
+        if (discussion.getMission() == null) {
+            return DiscussionResponse.createWithoutMission(discussion);
+        }
+
+        return DiscussionResponse.from(discussion);
     }
 }

--- a/backend/src/main/java/develup/application/discussion/DiscussionService.java
+++ b/backend/src/main/java/develup/application/discussion/DiscussionService.java
@@ -72,10 +72,12 @@ public class DiscussionService {
     }
 
     private List<HashTag> getHashTags(List<Long> hashTagIds) {
-        return hashTagIds.stream()
-                .map(id -> hashTagRepository.findById(id)
-                        .orElseThrow(() -> new DevelupException(ExceptionType.HASHTAG_NOT_FOUND)))
-                .toList();
+        List<HashTag> hashTags = hashTagRepository.findByIdIn(hashTagIds);
+
+        if (hashTagIds.size() != hashTags.size()) {
+            throw new DevelupException(ExceptionType.HASHTAG_NOT_FOUND);
+        }
+        return hashTags;
     }
 
     private DiscussionResponse createDiscussionResponse(Discussion discussion) {

--- a/backend/src/main/java/develup/application/discussion/SubmitDiscussionRequest.java
+++ b/backend/src/main/java/develup/application/discussion/SubmitDiscussionRequest.java
@@ -1,0 +1,12 @@
+package develup.application.discussion;
+
+import java.util.List;
+import jakarta.validation.constraints.NotBlank;
+
+public record SubmitDiscussionRequest(
+        @NotBlank String title,
+        @NotBlank String content,
+        Long missionId,
+        List<Long> hashTagIds
+) {
+}

--- a/backend/src/main/java/develup/domain/discussion/Discussion.java
+++ b/backend/src/main/java/develup/domain/discussion/Discussion.java
@@ -1,5 +1,6 @@
 package develup.domain.discussion;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import develup.domain.CreatedAtAuditableEntity;
@@ -80,6 +81,13 @@ public class Discussion extends CreatedAtAuditableEntity {
 
     public String getMissionTitle() {
         return mission.getTitle();
+    }
+
+    public List<HashTag> getHashTags() {
+        if (discussionHashTags == null || discussionHashTags.isEmpty()) {
+            return new ArrayList<>();
+        }
+        return discussionHashTags.extractHashTags();
     }
 
     public Set<DiscussionHashTag> getDiscussionHashTags() {

--- a/backend/src/main/java/develup/domain/discussion/Discussion.java
+++ b/backend/src/main/java/develup/domain/discussion/Discussion.java
@@ -1,6 +1,5 @@
 package develup.domain.discussion;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import develup.domain.CreatedAtAuditableEntity;
@@ -84,9 +83,6 @@ public class Discussion extends CreatedAtAuditableEntity {
     }
 
     public List<HashTag> getHashTags() {
-        if (discussionHashTags == null || discussionHashTags.isEmpty()) {
-            return new ArrayList<>();
-        }
         return discussionHashTags.extractHashTags();
     }
 

--- a/backend/src/main/java/develup/domain/discussion/Discussion.java
+++ b/backend/src/main/java/develup/domain/discussion/Discussion.java
@@ -16,8 +16,8 @@ import jakarta.persistence.ManyToOne;
 @Entity
 public class Discussion extends CreatedAtAuditableEntity {
 
-    @Column(nullable = false)
-    private String title;
+    @Embedded
+    private Title title;
 
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
@@ -37,7 +37,7 @@ public class Discussion extends CreatedAtAuditableEntity {
     }
 
     public Discussion(
-            String title,
+            Title title,
             String content,
             Mission mission,
             Member member,
@@ -48,7 +48,7 @@ public class Discussion extends CreatedAtAuditableEntity {
 
     public Discussion(
             Long id,
-            String title,
+            Title title,
             String content,
             Mission mission,
             Member member,
@@ -63,7 +63,7 @@ public class Discussion extends CreatedAtAuditableEntity {
     }
 
     public String getTitle() {
-        return title;
+        return title.getValue();
     }
 
     public String getContent() {

--- a/backend/src/main/java/develup/domain/discussion/DiscussionHashTags.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionHashTags.java
@@ -26,9 +26,6 @@ class DiscussionHashTags {
     }
 
     private Set<DiscussionHashTag> mapToDiscussionHashTag(Discussion target, List<HashTag> hashTags) {
-        if (hashTags == null) {
-            return new LinkedHashSet<>();
-        }
         return hashTags.stream()
                 .map(it -> new DiscussionHashTag(target, it))
                 .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/backend/src/main/java/develup/domain/discussion/DiscussionHashTags.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionHashTags.java
@@ -26,9 +26,22 @@ class DiscussionHashTags {
     }
 
     private Set<DiscussionHashTag> mapToDiscussionHashTag(Discussion target, List<HashTag> hashTags) {
+        if (hashTags == null) {
+            return new LinkedHashSet<>();
+        }
         return hashTags.stream()
                 .map(it -> new DiscussionHashTag(target, it))
                 .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    public boolean isEmpty() {
+        return hashTags.isEmpty();
+    }
+
+    public List<HashTag> extractHashTags() {
+        return hashTags.stream()
+                .map(DiscussionHashTag::getHashTag)
+                .toList();
     }
 
     public Set<DiscussionHashTag> getHashTags() {

--- a/backend/src/main/java/develup/domain/discussion/Title.java
+++ b/backend/src/main/java/develup/domain/discussion/Title.java
@@ -1,0 +1,45 @@
+package develup.domain.discussion;
+
+import java.util.Objects;
+import develup.api.exception.DevelupException;
+import develup.api.exception.ExceptionType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class Title {
+
+    @Column(name = "title")
+    private String value;
+
+    protected Title() {
+    }
+
+    public Title(String value) {
+        validateIsNotBlank(value);
+        this.value = value;
+    }
+
+    private void validateIsNotBlank(String value) {
+        if (value.isBlank()) {
+            throw new DevelupException(ExceptionType.INVALID_TITLE);
+        }
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Title title = (Title) o;
+        return Objects.equals(value, title.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+}

--- a/backend/src/main/java/develup/domain/hashtag/HashTagRepository.java
+++ b/backend/src/main/java/develup/domain/hashtag/HashTagRepository.java
@@ -1,6 +1,9 @@
 package develup.domain.hashtag;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HashTagRepository extends JpaRepository<HashTag, Long> {
+
+    List<HashTag> findByIdIn(List<Long> hashTagIds);
 }

--- a/backend/src/test/java/develup/api/DiscussionApiTest.java
+++ b/backend/src/test/java/develup/api/DiscussionApiTest.java
@@ -4,11 +4,14 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.List;
+import develup.application.discussion.DiscussionResponse;
+import develup.application.discussion.SubmitDiscussionRequest;
 import develup.application.discussion.SummarizedDiscussionResponse;
 import develup.domain.discussion.Discussion;
 import develup.domain.hashtag.HashTag;
@@ -21,6 +24,7 @@ import develup.support.data.MissionTestData;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
+import org.springframework.http.MediaType;
 
 public class DiscussionApiTest extends ApiTestSupport {
 
@@ -45,6 +49,39 @@ public class DiscussionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data[0].member.imageUrl", equalTo("image.com/1.jpg")))
                 .andExpect(jsonPath("$.data[0].commentCount", equalTo(100)))
                 .andExpect(jsonPath("$.data.length()", is(2)));
+    }
+
+    @Test
+    @DisplayName("디스커션을 제출한다.")
+    void submitDiscussion() throws Exception {
+        DiscussionResponse response = DiscussionResponse.from(createDiscussion());
+        SubmitDiscussionRequest request = new SubmitDiscussionRequest(
+                "루터회관 흡연단속 구현에 대한 고찰",
+                "루터회관 흡연단속을 구현하면서 느낀 점을 공유합니다.",
+                1L,
+                List.of(1L)
+        );
+        BDDMockito.given(discussionService.submit(any(), any()))
+                .willReturn(response);
+
+        mockMvc.perform(
+                        post("/discussions/submit")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id", equalTo(1)))
+                .andExpect(jsonPath("$.data.member.id", equalTo(1)))
+                .andExpect(jsonPath("$.data.member.email", equalTo("email@email.com")))
+                .andExpect(jsonPath("$.data.member.name", equalTo("tester")))
+                .andExpect(jsonPath("$.data.member.imageUrl", equalTo("image.com/1.jpg")))
+                .andExpect(jsonPath("$.data.title", equalTo("루터회관 흡연단속 구현에 대한 고찰")))
+                .andExpect(jsonPath("$.data.content", equalTo("루터회관 흡연단속을 구현하면서 느낀 점을 공유합니다.")))
+                .andExpect(jsonPath("$.data.mission.title", equalTo("루터회관 흡연단속")))
+                .andExpect(jsonPath("$.data.mission.summary", equalTo("담배피다 걸린 행성이를 위한 벌금 계산 미션")))
+                .andExpect(jsonPath("$.data.hashTags[0].id", equalTo(1)))
+                .andExpect(jsonPath("$.data.hashTags[0].name", equalTo("JAVA")));
     }
 
     private Discussion createDiscussion() {

--- a/backend/src/test/java/develup/api/DiscussionApiTest.java
+++ b/backend/src/test/java/develup/api/DiscussionApiTest.java
@@ -11,8 +11,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 import develup.application.discussion.DiscussionResponse;
-import develup.application.discussion.SubmitDiscussionRequest;
 import develup.application.discussion.SummarizedDiscussionResponse;
+import develup.application.discussion.CreateDiscussionRequest;
 import develup.domain.discussion.Discussion;
 import develup.domain.hashtag.HashTag;
 import develup.domain.member.Member;
@@ -53,15 +53,15 @@ public class DiscussionApiTest extends ApiTestSupport {
 
     @Test
     @DisplayName("디스커션을 제출한다.")
-    void submitDiscussion() throws Exception {
+    void createNewDiscussion() throws Exception {
         DiscussionResponse response = DiscussionResponse.from(createDiscussion());
-        SubmitDiscussionRequest request = new SubmitDiscussionRequest(
+        CreateDiscussionRequest request = new CreateDiscussionRequest(
                 "루터회관 흡연단속 구현에 대한 고찰",
                 "루터회관 흡연단속을 구현하면서 느낀 점을 공유합니다.",
                 1L,
                 List.of(1L)
         );
-        BDDMockito.given(discussionService.submit(any(), any()))
+        BDDMockito.given(discussionService.create(any(), any()))
                 .willReturn(response);
 
         mockMvc.perform(

--- a/backend/src/test/java/develup/application/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/develup/application/discussion/DiscussionServiceTest.java
@@ -70,10 +70,10 @@ class DiscussionServiceTest extends IntegrationTestSupport {
         Long missionId = missionRepository.save(MissionTestData.defaultMission().build()).getId();
         Long hashTagId = hashTagRepository.save(HashTagTestData.defaultHashTag().build()).getId();
 
-        SubmitDiscussionRequest request =
-                new SubmitDiscussionRequest("title", "content", missionId, List.of(hashTagId));
+        CreateDiscussionRequest request =
+                new CreateDiscussionRequest("title", "content", missionId, List.of(hashTagId));
 
-        DiscussionResponse response = discussionService.submit(memberId, request);
+        DiscussionResponse response = discussionService.create(memberId, request);
 
         assertAll(
                 () -> assertEquals(response.id(), 1L),
@@ -90,10 +90,10 @@ class DiscussionServiceTest extends IntegrationTestSupport {
         Long memberId = memberRepository.save(MemberTestData.defaultMember().build()).getId();
         Long hashTagId = hashTagRepository.save(HashTagTestData.defaultHashTag().build()).getId();
 
-        SubmitDiscussionRequest request =
-                new SubmitDiscussionRequest("title", "content", null, List.of(hashTagId));
+        CreateDiscussionRequest request =
+                new CreateDiscussionRequest("title", "content", null, List.of(hashTagId));
 
-        DiscussionResponse response = discussionService.submit(memberId, request);
+        DiscussionResponse response = discussionService.create(memberId, request);
 
         assertAll(
                 () -> assertEquals(response.id(), 1L),
@@ -110,10 +110,10 @@ class DiscussionServiceTest extends IntegrationTestSupport {
         Long memberId = memberRepository.save(MemberTestData.defaultMember().build()).getId();
         Long missionId = missionRepository.save(MissionTestData.defaultMission().build()).getId();
 
-        SubmitDiscussionRequest request =
-                new SubmitDiscussionRequest("title", "content", missionId, null);
+        CreateDiscussionRequest request =
+                new CreateDiscussionRequest("title", "content", missionId, null);
 
-        DiscussionResponse response = discussionService.submit(memberId, request);
+        DiscussionResponse response = discussionService.create(memberId, request);
 
         assertAll(
                 () -> assertEquals(response.id(), 1L),
@@ -126,45 +126,45 @@ class DiscussionServiceTest extends IntegrationTestSupport {
 
     @Test
     @DisplayName("존재하지 않는 사용자는 디스커션을 제출할 수 없다.")
-    void submitWithUnknownMember() {
+    void createWithUnknownMember() {
         Long unknownMemberId = -1L;
         Long missionId = missionRepository.save(MissionTestData.defaultMission().build()).getId();
         Long hashTagId = hashTagRepository.save(HashTagTestData.defaultHashTag().build()).getId();
 
-        SubmitDiscussionRequest request =
-                new SubmitDiscussionRequest("title", "content", missionId, List.of(hashTagId));
+        CreateDiscussionRequest request =
+                new CreateDiscussionRequest("title", "content", missionId, List.of(hashTagId));
 
-        assertThatThrownBy(() -> discussionService.submit(unknownMemberId, request))
+        assertThatThrownBy(() -> discussionService.create(unknownMemberId, request))
                 .isInstanceOf(DevelupException.class)
                 .hasMessage("존재하지 않는 회원입니다.");
     }
 
     @Test
     @DisplayName("존재하지 않는 미션을 디스커션에 태깅할 수 없다.")
-    void submitWithUnknownMission() {
+    void createWithUnknownMission() {
         Long unknownMissionId = -1L;
         Long memberId = memberRepository.save(MemberTestData.defaultMember().build()).getId();
         Long hashTagId = hashTagRepository.save(HashTagTestData.defaultHashTag().build()).getId();
 
-        SubmitDiscussionRequest request =
-                new SubmitDiscussionRequest("title", "content", unknownMissionId, List.of(hashTagId));
+        CreateDiscussionRequest request =
+                new CreateDiscussionRequest("title", "content", unknownMissionId, List.of(hashTagId));
 
-        assertThatThrownBy(() -> discussionService.submit(memberId, request))
+        assertThatThrownBy(() -> discussionService.create(memberId, request))
                 .isInstanceOf(DevelupException.class)
                 .hasMessage("존재하지 않는 미션입니다.");
     }
 
     @Test
     @DisplayName("존재하지 않는 해시태그를 디스커션에 태깅할 수 없다.")
-    void submitWithUnknownHashTag() {
+    void createWithUnknownHashTag() {
         Long unknownHashTagId = -1L;
         Long memberId = memberRepository.save(MemberTestData.defaultMember().build()).getId();
         Long missionId = missionRepository.save(MissionTestData.defaultMission().build()).getId();
 
-        SubmitDiscussionRequest request =
-                new SubmitDiscussionRequest("title", "content", missionId, List.of(unknownHashTagId));
+        CreateDiscussionRequest request =
+                new CreateDiscussionRequest("title", "content", missionId, List.of(unknownHashTagId));
 
-        assertThatThrownBy(() -> discussionService.submit(memberId, request))
+        assertThatThrownBy(() -> discussionService.create(memberId, request))
                 .isInstanceOf(DevelupException.class)
                 .hasMessage("존재하지 않는 해시태그입니다.");
     }

--- a/backend/src/test/java/develup/application/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/develup/application/discussion/DiscussionServiceTest.java
@@ -111,7 +111,7 @@ class DiscussionServiceTest extends IntegrationTestSupport {
         Long missionId = missionRepository.save(MissionTestData.defaultMission().build()).getId();
 
         CreateDiscussionRequest request =
-                new CreateDiscussionRequest("title", "content", missionId, null);
+                new CreateDiscussionRequest("title", "content", missionId, List.of());
 
         DiscussionResponse response = discussionService.create(memberId, request);
 

--- a/backend/src/test/java/develup/domain/discussion/DiscussionTest.java
+++ b/backend/src/test/java/develup/domain/discussion/DiscussionTest.java
@@ -1,8 +1,13 @@
 package develup.domain.discussion;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import java.util.ArrayList;
+import java.util.List;
+import develup.domain.hashtag.HashTag;
 import develup.support.data.DiscussionTestData;
+import develup.support.data.HashTagTestData;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -13,5 +18,26 @@ class DiscussionTest {
     void create() {
         assertThatCode(() -> DiscussionTestData.defaultDiscussion().build())
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("디스커션 해시 태그 객체를 해시 태그 객체로 변환한다.")
+    void getHashTags() {
+        List<HashTag> hashTags = List.of(HashTagTestData.defaultHashTag().build());
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withHashTags(hashTags)
+                .build();
+
+        assertThat(discussion.getHashTags()).containsExactlyElementsOf(hashTags);
+    }
+
+    @Test
+    @DisplayName("디스커션 해시 태그가 비어 있으면 빈 리스트를 반환한다.")
+    void getHashTagsWithEmpty() {
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withHashTags(new ArrayList<>())
+                .build();
+
+        assertThat(discussion.getHashTags()).isEmpty();
     }
 }

--- a/backend/src/test/java/develup/support/data/DiscussionTestData.java
+++ b/backend/src/test/java/develup/support/data/DiscussionTestData.java
@@ -3,6 +3,7 @@ package develup.support.data;
 import java.util.Collections;
 import java.util.List;
 import develup.domain.discussion.Discussion;
+import develup.domain.discussion.Title;
 import develup.domain.hashtag.HashTag;
 import develup.domain.member.Member;
 import develup.domain.mission.Mission;
@@ -21,7 +22,7 @@ public class DiscussionTestData {
     public static class DiscussionBuilder {
 
         private Long id;
-        private String title;
+        private Title title;
         private String content;
         private Mission mission;
         private Member member;
@@ -33,7 +34,7 @@ public class DiscussionTestData {
         }
 
         public DiscussionBuilder withTitle(String title) {
-            this.title = title;
+            this.title = new Title(title);
             return this;
         }
 


### PR DESCRIPTION
#### 구현 요약

- 디스커션 제출 기능을 구현했습니다.
- 미션과 해시태그가 태깅되지 않아도 저장되도록 구현했습니다.

#### 연관 이슈

- close #437

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
