### PR TITLE
댓글 기능 다시 구현 (issue #449)

### DIFF
--- a/backend/src/main/java/develup/api/DiscussionCommentApi.java
+++ b/backend/src/main/java/develup/api/DiscussionCommentApi.java
@@ -1,0 +1,90 @@
+package develup.api;
+
+import java.net.URI;
+import java.util.List;
+import develup.api.auth.Auth;
+import develup.api.common.ApiResponse;
+import develup.application.auth.Accessor;
+import develup.application.discussion.comment.CreateDiscussionCommentResponse;
+import develup.application.discussion.comment.DiscussionCommentRepliesResponse;
+import develup.application.discussion.comment.DiscussionCommentRequest;
+import develup.application.discussion.comment.DiscussionCommentService;
+import develup.application.discussion.comment.MyDiscussionCommentResponse;
+import develup.application.discussion.comment.UpdateDiscussionCommentRequest;
+import develup.application.discussion.comment.UpdateDiscussionCommentResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Tag(name = "디스커션 댓글 API")
+public class DiscussionCommentApi {
+
+    private final DiscussionCommentService discussionCommentService;
+
+    public DiscussionCommentApi(DiscussionCommentService discussionCommentService) {
+        this.discussionCommentService = discussionCommentService;
+    }
+
+    @GetMapping("/discussions/{discussionId}/comments")
+    @Operation(summary = "디스커션 댓글 조회 API", description = "디스커션의 댓글 목록을 조회합니다. 댓글들과 댓글들에 대한 답글을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<DiscussionCommentRepliesResponse>>> getComments(
+            @PathVariable Long discussionId
+    ) {
+        List<DiscussionCommentRepliesResponse> responses = discussionCommentService.getCommentsWithReplies(discussionId);
+
+        return ResponseEntity.ok(new ApiResponse<>(responses));
+    }
+
+    @GetMapping("/discussions/comments/mine")
+    @Operation(summary = "사용자가 디스커션에 단 댓글 조회 API", description = "사용자가 디스커션에 단 댓글 목록을 조회합니다. 댓글 정보와 댓글이 달린 디스커션의 일부 정보를 조회합니다.")
+    public ResponseEntity<ApiResponse<List<MyDiscussionCommentResponse>>> getMyComments(@Auth Accessor accessor) {
+        List<MyDiscussionCommentResponse> responses = discussionCommentService.getMyComments(accessor.id());
+        return ResponseEntity.ok(new ApiResponse<>(responses));
+    }
+
+    @PostMapping("/discussions/{discussionId}/comments")
+    @Operation(summary = "디스커션 댓글 추가 API", description = "디스커션에 댓글을 추가합니다. 부모 댓글 식별자로 답글을 추가할 수 있습니다.")
+    public ResponseEntity<ApiResponse<CreateDiscussionCommentResponse>> addComment(
+            @PathVariable Long discussionId,
+            @Valid @RequestBody DiscussionCommentRequest request,
+            @Auth Accessor accessor
+    ) {
+        CreateDiscussionCommentResponse response = discussionCommentService.addComment(discussionId, request, accessor.id());
+
+        URI location = URI.create("/discussions/" + response.discussionId() + "/comments/" + response.id());
+
+        return ResponseEntity.created(location).body(new ApiResponse<>(response));
+    }
+
+    @PatchMapping("/discussions/comments/{commentId}")
+    @Operation(summary = "디스커션 댓글 수정 API", description = "디스커션의 댓글을 수정합니다.")
+    public ResponseEntity<ApiResponse<UpdateDiscussionCommentResponse>> updateComment(
+            @PathVariable Long commentId,
+            @Valid @RequestBody UpdateDiscussionCommentRequest request,
+            @Auth Accessor accessor
+    ) {
+        UpdateDiscussionCommentResponse response = discussionCommentService.updateComment(commentId, request, accessor.id());
+
+        return ResponseEntity.ok(new ApiResponse<>(response));
+    }
+
+    @DeleteMapping("/discussions/comments/{commentId}")
+    @Operation(summary = "디스커션 댓글 삭제 API", description = "디스커션의 댓글을 삭제합니다.")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long commentId,
+            @Auth Accessor accessor
+    ) {
+        discussionCommentService.deleteComment(commentId, accessor.id());
+
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/develup/application/discussion/comment/CreateDiscussionCommentResponse.java
+++ b/backend/src/main/java/develup/application/discussion/comment/CreateDiscussionCommentResponse.java
@@ -1,0 +1,31 @@
+package develup.application.discussion.comment;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import develup.application.member.MemberResponse;
+import develup.domain.discussion.comment.DiscussionComment;
+
+public record CreateDiscussionCommentResponse(
+        Long id,
+        Long discussionId,
+        Long parentCommentId,
+        String content,
+        MemberResponse member,
+        LocalDateTime createdAt
+) {
+
+    public static CreateDiscussionCommentResponse from(DiscussionComment comment) {
+        Long parentCommentId = Optional.ofNullable(comment.getParentComment())
+                .map(DiscussionComment::getId)
+                .orElse(null);
+
+        return new CreateDiscussionCommentResponse(
+                comment.getId(),
+                comment.getDiscussionId(),
+                parentCommentId,
+                comment.getContent(),
+                MemberResponse.from(comment.getMember()),
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentGroupingService.java
+++ b/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentGroupingService.java
@@ -1,0 +1,57 @@
+package develup.application.discussion.comment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import develup.domain.discussion.comment.DiscussionComment;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DiscussionCommentGroupingService {
+
+    public List<DiscussionCommentRepliesResponse> groupReplies(List<DiscussionComment> comments) {
+        List<DiscussionComment> rootComments = filterRootComments(comments);
+
+        Map<Long, List<DiscussionComment>> repliesMap = createRepliesMapByRootCommentId(comments);
+        List<DiscussionCommentRepliesResponse> commentWithReplies = attachRepliesToRootComments(rootComments, repliesMap);
+
+        return commentWithReplies.stream()
+                .filter(this::isRootCommentNotDeletedOrHasReplies)
+                .toList();
+    }
+
+    private List<DiscussionComment> filterRootComments(List<DiscussionComment> comments) {
+        return comments.stream()
+                .filter(DiscussionComment::isRootComment)
+                .toList();
+    }
+
+    private Map<Long, List<DiscussionComment>> createRepliesMapByRootCommentId(List<DiscussionComment> comments) {
+        return comments.stream()
+                .filter(DiscussionComment::isReply)
+                .filter(DiscussionComment::isNotDeleted)
+                .collect(Collectors.groupingBy(DiscussionComment::getParentCommentId));
+    }
+
+    private List<DiscussionCommentRepliesResponse> attachRepliesToRootComments(
+            List<DiscussionComment> rootComments,
+            Map<Long, List<DiscussionComment>> repliesMap
+    ) {
+        return rootComments.stream()
+                .map(rootComment -> createSolutionCommentRepliesResponse(rootComment, repliesMap))
+                .toList();
+    }
+
+    private DiscussionCommentRepliesResponse createSolutionCommentRepliesResponse(
+            DiscussionComment rootComment,
+            Map<Long, List<DiscussionComment>> repliesMap
+    ) {
+        List<DiscussionComment> replies = repliesMap.getOrDefault(rootComment.getId(), List.of());
+
+        return DiscussionCommentRepliesResponse.of(rootComment, replies);
+    }
+
+    private boolean isRootCommentNotDeletedOrHasReplies(DiscussionCommentRepliesResponse rootCommentResponse) {
+        return !rootCommentResponse.isDeleted() || !rootCommentResponse.replies().isEmpty();
+    }
+}

--- a/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentRepliesResponse.java
+++ b/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentRepliesResponse.java
@@ -1,0 +1,60 @@
+package develup.application.discussion.comment;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import develup.application.member.MemberResponse;
+import develup.domain.discussion.comment.DiscussionComment;
+
+public record DiscussionCommentRepliesResponse(
+        Long id,
+        Long discussionId,
+        String content,
+        MemberResponse member,
+        List<DiscussionReplyResponse> replies,
+        LocalDateTime createdAt,
+        boolean isDeleted
+) {
+
+    private static final LocalDateTime EPOCH_TIME = LocalDateTime.ofEpochSecond(0, 0, ZoneOffset.UTC);
+    private static final MemberResponse EMPTY_MEMBER = new MemberResponse(0L, "", "", "");
+
+    public static DiscussionCommentRepliesResponse of(
+            DiscussionComment rootComment,
+            List<DiscussionComment> replies
+    ) {
+        List<DiscussionReplyResponse> replyResponses = replies.stream()
+                .map(DiscussionReplyResponse::from)
+                .toList();
+
+
+        if (rootComment.isDeleted()) {
+            return ofDeleted(rootComment, replyResponses);
+        }
+
+        return new DiscussionCommentRepliesResponse(
+                rootComment.getId(),
+                rootComment.getDiscussionId(),
+                rootComment.getContent(),
+                MemberResponse.from(rootComment.getMember()),
+                replyResponses,
+                rootComment.getCreatedAt(),
+                false
+        );
+    }
+
+    private static DiscussionCommentRepliesResponse ofDeleted(
+            DiscussionComment rootComment,
+            List<DiscussionReplyResponse> replyResponses
+    ) {
+        return new DiscussionCommentRepliesResponse(
+                rootComment.getId(),
+                rootComment.getDiscussionId(),
+                "",
+                EMPTY_MEMBER,
+                replyResponses,
+                EPOCH_TIME,
+                true
+        );
+    }
+}

--- a/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentRequest.java
+++ b/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentRequest.java
@@ -1,0 +1,9 @@
+package develup.application.discussion.comment;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DiscussionCommentRequest(
+        @NotBlank String content,
+        Long parentCommentId
+) {
+}

--- a/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentService.java
+++ b/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentService.java
@@ -1,0 +1,119 @@
+package develup.application.discussion.comment;
+
+import java.util.List;
+import develup.api.exception.DevelupException;
+import develup.api.exception.ExceptionType;
+import develup.domain.discussion.Discussion;
+import develup.domain.discussion.DiscussionRepository;
+import develup.domain.discussion.comment.DiscussionComment;
+import develup.domain.discussion.comment.DiscussionCommentRepository;
+import develup.domain.discussion.comment.MyDiscussionComment;
+import develup.domain.member.Member;
+import develup.domain.member.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class DiscussionCommentService {
+
+    private final DiscussionCommentGroupingService commentGroupingService;
+    private final DiscussionCommentRepository discussionCommentRepository;
+    private final MemberRepository memberRepository;
+    private final DiscussionRepository discussionRepository;
+
+    public DiscussionCommentService(
+            DiscussionCommentGroupingService commentGroupingService,
+            DiscussionCommentRepository discussionCommentRepository,
+            MemberRepository memberRepository,
+            DiscussionRepository discussionRepository
+    ) {
+        this.commentGroupingService = commentGroupingService;
+        this.discussionCommentRepository = discussionCommentRepository;
+        this.memberRepository = memberRepository;
+        this.discussionRepository = discussionRepository;
+    }
+
+    public DiscussionComment getComment(Long commentId) {
+        DiscussionComment comment = discussionCommentRepository.findById(commentId)
+                .orElseThrow(() -> new DevelupException(ExceptionType.COMMENT_NOT_FOUND));
+
+        if (comment.isDeleted()) {
+            throw new DevelupException(ExceptionType.COMMENT_NOT_FOUND);
+        }
+
+        return comment;
+    }
+
+    public List<DiscussionCommentRepliesResponse> getCommentsWithReplies(Long discussionId) {
+        List<DiscussionComment> comments = discussionCommentRepository.findAllByDiscussion_IdOrderByCreatedAtAsc(discussionId);
+
+        return commentGroupingService.groupReplies(comments);
+    }
+
+    public List<MyDiscussionCommentResponse> getMyComments(Long memberId) {
+        List<MyDiscussionComment> mySolutionComments = discussionCommentRepository.findAllMyDiscussionComment(memberId);
+
+        return mySolutionComments.stream()
+                .map(MyDiscussionCommentResponse::from)
+                .toList();
+    }
+
+    public CreateDiscussionCommentResponse addComment(Long discussionId, DiscussionCommentRequest request, Long memberId) {
+        Member member = getMember(memberId);
+        Discussion discussion = getDiscussion(discussionId);
+
+        boolean isReply = request.parentCommentId() != null;
+        if (isReply) {
+            DiscussionComment reply = createReply(request, member);
+            return CreateDiscussionCommentResponse.from(reply);
+        }
+
+        DiscussionComment rootComment = createRootComment(request, discussion, member);
+        return CreateDiscussionCommentResponse.from(rootComment);
+    }
+
+    private DiscussionComment createReply(DiscussionCommentRequest request, Member member) {
+        DiscussionComment parentComment = getComment(request.parentCommentId());
+        DiscussionComment reply = parentComment.reply(request.content(), member);
+
+        return discussionCommentRepository.save(reply);
+    }
+
+    private DiscussionComment createRootComment(DiscussionCommentRequest request, Discussion discussion, Member member) {
+        DiscussionComment rootComment = DiscussionComment.create(request.content(), discussion, member);
+
+        return discussionCommentRepository.save(rootComment);
+    }
+
+    public UpdateDiscussionCommentResponse updateComment(Long commentId, UpdateDiscussionCommentRequest request, Long id) {
+        DiscussionComment comment = getComment(commentId);
+        if (comment.isNotWrittenBy(id)) {
+            throw new DevelupException(ExceptionType.COMMENT_NOT_WRITTEN_BY_MEMBER);
+        }
+
+        comment.updateContent(request.content());
+
+        return UpdateDiscussionCommentResponse.from(comment);
+    }
+
+    public void deleteComment(Long commentId, Long memberId) {
+        DiscussionComment comment = getComment(commentId);
+
+        if (comment.isNotWrittenBy(memberId)) {
+            throw new DevelupException(ExceptionType.COMMENT_NOT_WRITTEN_BY_MEMBER);
+        }
+
+        comment.delete();
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new DevelupException(ExceptionType.MEMBER_NOT_FOUND));
+    }
+
+    private Discussion getDiscussion(Long discussionId) {
+        return discussionRepository.findById(discussionId)
+                .orElseThrow(() -> new DevelupException(ExceptionType.SOLUTION_NOT_FOUND));
+    }
+}

--- a/backend/src/main/java/develup/application/discussion/comment/DiscussionReplyResponse.java
+++ b/backend/src/main/java/develup/application/discussion/comment/DiscussionReplyResponse.java
@@ -1,0 +1,26 @@
+package develup.application.discussion.comment;
+
+import java.time.LocalDateTime;
+import develup.application.member.MemberResponse;
+import develup.domain.discussion.comment.DiscussionComment;
+
+public record DiscussionReplyResponse(
+        Long id,
+        Long discussionId,
+        Long parentCommentId,
+        String content,
+        MemberResponse member,
+        LocalDateTime createdAt
+) {
+
+    public static DiscussionReplyResponse from(DiscussionComment reply) {
+        return new DiscussionReplyResponse(
+                reply.getId(),
+                reply.getDiscussionId(),
+                reply.getParentCommentId(),
+                reply.getContent(),
+                MemberResponse.from(reply.getMember()),
+                reply.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/develup/application/discussion/comment/MyDiscussionCommentResponse.java
+++ b/backend/src/main/java/develup/application/discussion/comment/MyDiscussionCommentResponse.java
@@ -1,0 +1,25 @@
+package develup.application.discussion.comment;
+
+import java.time.LocalDateTime;
+import develup.domain.discussion.comment.MyDiscussionComment;
+
+public record MyDiscussionCommentResponse(
+        Long id,
+        Long discussionId,
+        String content,
+        LocalDateTime createdAt,
+        String discussionTitle,
+        Long discussionCommentCount
+) {
+
+    public static MyDiscussionCommentResponse from(MyDiscussionComment myDiscussionComment) {
+        return new MyDiscussionCommentResponse(
+                myDiscussionComment.id(),
+                myDiscussionComment.discussionId(),
+                myDiscussionComment.content(),
+                myDiscussionComment.createdAt(),
+                myDiscussionComment.discussionTitle(),
+                myDiscussionComment.discussionCommentCount()
+        );
+    }
+}

--- a/backend/src/main/java/develup/application/discussion/comment/UpdateDiscussionCommentRequest.java
+++ b/backend/src/main/java/develup/application/discussion/comment/UpdateDiscussionCommentRequest.java
@@ -1,0 +1,8 @@
+package develup.application.discussion.comment;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateDiscussionCommentRequest(
+        @NotBlank String content
+) {
+}

--- a/backend/src/main/java/develup/application/discussion/comment/UpdateDiscussionCommentResponse.java
+++ b/backend/src/main/java/develup/application/discussion/comment/UpdateDiscussionCommentResponse.java
@@ -1,0 +1,24 @@
+package develup.application.discussion.comment;
+
+import java.time.LocalDateTime;
+import develup.application.member.MemberResponse;
+import develup.domain.discussion.comment.DiscussionComment;
+
+public record UpdateDiscussionCommentResponse(
+        Long id,
+        Long discussionId,
+        String content,
+        MemberResponse member,
+        LocalDateTime createdAt
+) {
+
+    public static UpdateDiscussionCommentResponse from(DiscussionComment comment) {
+        return new UpdateDiscussionCommentResponse(
+                comment.getId(),
+                comment.getDiscussionId(),
+                comment.getContent(),
+                MemberResponse.from(comment.getMember()),
+                comment.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/develup/domain/discussion/comment/DiscussionComment.java
+++ b/backend/src/main/java/develup/domain/discussion/comment/DiscussionComment.java
@@ -1,0 +1,150 @@
+package develup.domain.discussion.comment;
+
+import java.time.LocalDateTime;
+import develup.api.exception.DevelupException;
+import develup.api.exception.ExceptionType;
+import develup.domain.CreatedAtAuditableEntity;
+import develup.domain.discussion.Discussion;
+import develup.domain.member.Member;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class DiscussionComment extends CreatedAtAuditableEntity {
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "discussion_id", nullable = false)
+    private Discussion discussion;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private DiscussionComment parentComment;
+
+    @Column
+    private LocalDateTime deletedAt;
+
+    protected DiscussionComment() {
+    }
+
+    public DiscussionComment(
+            String content,
+            Discussion discussion,
+            Member member,
+            DiscussionComment parentComment,
+            LocalDateTime deletedAt
+    ) {
+        this(null, content, discussion, member, parentComment, deletedAt);
+    }
+
+    public DiscussionComment(
+            Long id,
+            String content,
+            Discussion discussion,
+            Member member,
+            DiscussionComment parentComment,
+            LocalDateTime deletedAt
+    ) {
+        super(id);
+        this.content = content;
+        this.discussion = discussion;
+        this.member = member;
+        this.parentComment = parentComment;
+        this.deletedAt = deletedAt;
+    }
+
+    public static DiscussionComment create(String content, Discussion discussion, Member member) {
+        return new DiscussionComment(content, discussion, member, null, null);
+    }
+
+    public DiscussionComment reply(String content, Member member) {
+        if (this.isDeleted()) {
+            throw new DevelupException(ExceptionType.COMMENT_ALREADY_DELETED);
+        }
+
+        if (this.isReply()) {
+            throw new DevelupException(ExceptionType.CANNOT_REPLY_TO_REPLY);
+        }
+
+        DiscussionComment reply = new DiscussionComment();
+        reply.content = content;
+        reply.discussion = this.discussion;
+        reply.member = member;
+        reply.parentComment = this;
+
+        return reply;
+    }
+
+    public void updateContent(String content) {
+        if (this.isDeleted()) {
+            throw new DevelupException(ExceptionType.COMMENT_ALREADY_DELETED);
+        }
+
+        this.content = content;
+    }
+
+    public void delete() {
+        if (this.isDeleted()) {
+            throw new DevelupException(ExceptionType.COMMENT_ALREADY_DELETED);
+        }
+
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public Discussion getDiscussion() {
+        return discussion;
+    }
+
+    public Long getDiscussionId() {
+        return discussion.getId();
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public boolean isNotWrittenBy(Long memberId) {
+        return !member.getId().equals(memberId);
+    }
+
+    public DiscussionComment getParentComment() {
+        return parentComment;
+    }
+
+    public Long getParentCommentId() {
+        return parentComment.getId();
+    }
+
+    public boolean isRootComment() {
+        return parentComment == null;
+    }
+
+    public boolean isReply() {
+        return parentComment != null;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
+    }
+
+    public boolean isNotDeleted() {
+        return deletedAt == null;
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
+}

--- a/backend/src/main/java/develup/domain/discussion/comment/DiscussionCommentRepository.java
+++ b/backend/src/main/java/develup/domain/discussion/comment/DiscussionCommentRepository.java
@@ -1,0 +1,21 @@
+package develup.domain.discussion.comment;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface DiscussionCommentRepository extends JpaRepository<DiscussionComment, Long> {
+
+    List<DiscussionComment> findAllByDiscussion_IdOrderByCreatedAtAsc(Long discussionId);
+
+    @Query("""
+            SELECT new develup.domain.discussion.comment.MyDiscussionComment(
+                dc.id, dc.discussion.id, dc.content, dc.createdAt, d.title, COUNT(dc))
+            FROM DiscussionComment dc
+            JOIN dc.discussion d
+            JOIN dc.member m
+            WHERE dc.member.id = :memberId AND dc.deletedAt is null
+            GROUP BY dc.id
+            """)
+    List<MyDiscussionComment> findAllMyDiscussionComment(Long memberId);
+}

--- a/backend/src/main/java/develup/domain/discussion/comment/DiscussionCommentRepository.java
+++ b/backend/src/main/java/develup/domain/discussion/comment/DiscussionCommentRepository.java
@@ -10,7 +10,7 @@ public interface DiscussionCommentRepository extends JpaRepository<DiscussionCom
 
     @Query("""
             SELECT new develup.domain.discussion.comment.MyDiscussionComment(
-                dc.id, dc.discussion.id, dc.content, dc.createdAt, d.title, COUNT(dc))
+                dc.id, dc.discussion.id, dc.content, dc.createdAt, d.title.value, COUNT(dc))
             FROM DiscussionComment dc
             JOIN dc.discussion d
             JOIN dc.member m

--- a/backend/src/main/java/develup/domain/discussion/comment/MyDiscussionComment.java
+++ b/backend/src/main/java/develup/domain/discussion/comment/MyDiscussionComment.java
@@ -1,0 +1,13 @@
+package develup.domain.discussion.comment;
+
+import java.time.LocalDateTime;
+
+public record MyDiscussionComment(
+        Long id,
+        Long discussionId,
+        String content,
+        LocalDateTime createdAt,
+        String discussionTitle,
+        Long discussionCommentCount
+) {
+}

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -87,3 +87,19 @@ VALUES (1, 1),
        (2, 1),
        (2, 2),
        (2, 3);
+
+-- root-1
+-- ㄴ root-1-1
+-- ㄴ root-1-2
+-- root-2 (deleted, view o)
+-- ㄴ root-2-1
+-- ㄴ root-2-2 (deleted, view x)
+-- root-3 (deleted, view x)
+INSERT INTO discussion_comment (discussion_id, member_id, content, parent_comment_id, deleted_at, created_at)
+VALUES (1, 1, '1', NULL, NULL, '2024-08-16 13:40:00'),
+       (1, 1, '2', NULL, '2024-08-12 13:40:00', '2024-08-16 13:40:00'),
+       (1, 1, '3', NULL, '2024-08-12 13:40:00', '2024-08-16 13:40:00'),
+       (1, 1, '2-1', 2, NULL, '2024-08-16 13:40:00'),
+       (1, 1, '1-1', 1, NULL, '2024-08-16 13:40:00'),
+       (1, 1, '2-2', 2, '2024-08-12 13:40:00', '2024-08-16 13:40:00'),
+       (1, 1, '1-2', 1, NULL, '2024-08-16 13:40:00');

--- a/backend/src/test/java/develup/api/ApiTestSupport.java
+++ b/backend/src/test/java/develup/api/ApiTestSupport.java
@@ -5,6 +5,7 @@ import develup.api.auth.AuthArgumentResolver;
 import develup.api.auth.CookieAuthorizationExtractor;
 import develup.application.auth.AuthService;
 import develup.application.discussion.DiscussionService;
+import develup.application.discussion.comment.DiscussionCommentService;
 import develup.application.hashtag.HashTagService;
 import develup.application.member.MemberService;
 import develup.application.mission.MissionService;
@@ -44,6 +45,9 @@ public class ApiTestSupport {
 
     @MockBean
     protected DiscussionService discussionService;
+
+    @MockBean
+    protected DiscussionCommentService discussionCommentService;
 
     @MockBean
     protected AuthArgumentResolver argumentResolver;

--- a/backend/src/test/java/develup/api/DiscussionCommentApiTest.java
+++ b/backend/src/test/java/develup/api/DiscussionCommentApiTest.java
@@ -1,0 +1,174 @@
+package develup.api;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import develup.application.discussion.comment.CreateDiscussionCommentResponse;
+import develup.application.discussion.comment.DiscussionCommentRepliesResponse;
+import develup.application.discussion.comment.DiscussionCommentRequest;
+import develup.application.discussion.comment.DiscussionReplyResponse;
+import develup.application.discussion.comment.MyDiscussionCommentResponse;
+import develup.application.discussion.comment.UpdateDiscussionCommentRequest;
+import develup.application.discussion.comment.UpdateDiscussionCommentResponse;
+import develup.application.member.MemberResponse;
+import develup.domain.member.Member;
+import develup.support.data.MemberTestData;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.springframework.http.MediaType;
+
+class DiscussionCommentApiTest extends ApiTestSupport {
+
+    @Test
+    @DisplayName("댓글 목록을 조회한다.")
+    void getComments() throws Exception {
+        DiscussionReplyResponse replyResponse = createReplyResponse();
+        List<DiscussionReplyResponse> replyResponses = List.of(replyResponse);
+        List<DiscussionCommentRepliesResponse> responses = List.of(createRootCommentResponse(replyResponses));
+
+        BDDMockito.given(discussionCommentService.getCommentsWithReplies(any()))
+                .willReturn(responses);
+
+        mockMvc.perform(
+                        get("/discussions/1/comments"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id", equalTo(1)))
+                .andExpect(jsonPath("$.data[0].content", equalTo("content")))
+                .andExpect(jsonPath("$.data[0].replies", hasSize(1)))
+                .andExpect(jsonPath("$.data[0].replies[0].id", equalTo(2)));
+    }
+
+    @Test
+    @DisplayName("내가 디스커션에 작성한 댓글 목록을 조회한다.")
+    void getMyComments() throws Exception {
+        LocalDateTime now = LocalDateTime.now();
+        MyDiscussionCommentResponse myDiscussionCommentResponse = new MyDiscussionCommentResponse(1L, 1L, "댓글 내용", now, "디스커션 제목", 123L);
+        List<MyDiscussionCommentResponse> responses = List.of(myDiscussionCommentResponse);
+
+        BDDMockito.given(discussionCommentService.getMyComments(any()))
+                .willReturn(responses);
+
+        mockMvc.perform(
+                        get("/discussions/comments/mine"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id", equalTo(1)))
+                .andExpect(jsonPath("$.data[0].discussionId", equalTo(1)))
+                .andExpect(jsonPath("$.data[0].content", equalTo("댓글 내용")))
+                .andExpect(jsonPath("$.data[0].createdAt").exists())
+                .andExpect(jsonPath("$.data[0].discussionTitle", equalTo("디스커션 제목")))
+                .andExpect(jsonPath("$.data[0].discussionCommentCount", equalTo(123)));
+    }
+
+    @Test
+    @DisplayName("댓글을 추가한다.")
+    void addComment() throws Exception {
+        Member member = MemberTestData.defaultMember().withId(1L).build();
+        MemberResponse memberResponse = MemberResponse.from(member);
+        CreateDiscussionCommentResponse response = new CreateDiscussionCommentResponse(
+                1L,
+                1L,
+                null,
+                "content",
+                memberResponse,
+                LocalDateTime.now()
+        );
+        BDDMockito.given(discussionCommentService.addComment(any(), any(), any()))
+                .willReturn(response);
+
+        DiscussionCommentRequest request = new DiscussionCommentRequest("content", null);
+        mockMvc.perform(
+                        post("/discussions/1/comments")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.id", equalTo(1)))
+                .andExpect(jsonPath("$.data.content", equalTo("content")))
+                .andExpect(jsonPath("$.data.parentCommentId", equalTo(null)))
+                .andExpect(jsonPath("$.data.member.id", equalTo(1)))
+                .andExpect(jsonPath("$.data.createdAt").exists());
+    }
+
+    @Test
+    @DisplayName("댓글 내용을 수정한다.")
+    void updateComment() throws Exception {
+        Member member = MemberTestData.defaultMember().withId(1L).build();
+        MemberResponse memberResponse = MemberResponse.from(member);
+        UpdateDiscussionCommentRequest request = new UpdateDiscussionCommentRequest("updated content");
+        UpdateDiscussionCommentResponse response = new UpdateDiscussionCommentResponse(
+                1L,
+                1L,
+                "updated content",
+                memberResponse,
+                LocalDateTime.now()
+        );
+
+        BDDMockito.given(discussionCommentService.updateComment(any(), any(), any()))
+                .willReturn(response);
+
+        mockMvc.perform(
+                        patch("/discussions/comments/1")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request))
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id", equalTo(1)))
+                .andExpect(jsonPath("$.data.discussionId", equalTo(1)))
+                .andExpect(jsonPath("$.data.member.id", equalTo(1)))
+                .andExpect(jsonPath("$.data.createdAt").exists())
+                .andExpect(jsonPath("$.data.content", equalTo("updated content")));
+    }
+
+    @Test
+    @DisplayName("댓글을 삭제한다.")
+    void deleteComment() throws Exception {
+        BDDMockito.doNothing()
+                .when(discussionCommentService)
+                .deleteComment(any(), any());
+
+        mockMvc.perform(
+                        delete("/discussions/comments/1")
+                                .cookie(new Cookie("token", "mock_token"))
+                )
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    private DiscussionCommentRepliesResponse createRootCommentResponse(List<DiscussionReplyResponse> replyResponses) {
+        return new DiscussionCommentRepliesResponse(
+                1L,
+                1L,
+                "content",
+                MemberResponse.from(MemberTestData.defaultMember().withId(1L).build()),
+                replyResponses,
+                LocalDateTime.now(),
+                false
+        );
+    }
+
+    private DiscussionReplyResponse createReplyResponse() {
+        return new DiscussionReplyResponse(
+                2L,
+                1L,
+                1L,
+                "reply",
+                MemberResponse.from(MemberTestData.defaultMember().withId(1L).build()),
+                LocalDateTime.now()
+        );
+    }
+}

--- a/backend/src/test/java/develup/application/discussion/comment/DiscussionCommentGroupingServiceTest.java
+++ b/backend/src/test/java/develup/application/discussion/comment/DiscussionCommentGroupingServiceTest.java
@@ -1,0 +1,75 @@
+package develup.application.discussion.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import develup.domain.discussion.comment.DiscussionComment;
+import develup.support.IntegrationTestSupport;
+import develup.support.data.DiscussionCommentTestData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class DiscussionCommentGroupingServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private DiscussionCommentGroupingService commentGroupingService;
+
+    /**
+     * [계층 구조]
+     * root1
+     * - root1reply1 (삭제됨 - 안보임)
+     * - root1reply2
+     * root2 (삭제됨 - 보임)
+     * - root2reply1
+     * - root2reply2
+     */
+    @Test
+    @DisplayName("댓글을 그룹화한다.")
+    void groupReplies() {
+        List<DiscussionComment> comments = createComments();
+
+        List<DiscussionCommentRepliesResponse> rootCommentResponses = commentGroupingService.groupReplies(comments);
+
+        assertAll(
+                () -> assertThat(rootCommentResponses).hasSize(2),
+                () -> assertThat(rootCommentResponses.get(0).replies()).hasSize(1),
+                () -> assertThat(rootCommentResponses.get(1).replies()).hasSize(2),
+                () -> assertThat(rootCommentResponses.get(0).replies().get(0)).isNotNull(),
+                () -> assertThat(rootCommentResponses.get(1).isDeleted()).isTrue(),
+                () -> assertThat(rootCommentResponses.get(1).replies().get(0)).isNotNull(),
+                () -> assertThat(rootCommentResponses.get(1).replies().get(1)).isNotNull()
+        );
+    }
+
+    private List<DiscussionComment> createComments() {
+        DiscussionComment root1 = DiscussionCommentTestData.defaultDiscussionComment()
+                .withId(1L)
+                .build();
+        DiscussionComment root2 = DiscussionCommentTestData.defaultDiscussionComment()
+                .withId(2L)
+                .withDeletedAt(LocalDateTime.now())
+                .build();
+        DiscussionComment root1reply1 = DiscussionCommentTestData.defaultDiscussionComment()
+                .withId(3L)
+                .withDeletedAt(LocalDateTime.now())
+                .withParentComment(root1)
+                .build();
+        DiscussionComment root1reply2 = DiscussionCommentTestData.defaultDiscussionComment()
+                .withId(4L)
+                .withParentComment(root1)
+                .build();
+        DiscussionComment root2reply1 = DiscussionCommentTestData.defaultDiscussionComment()
+                .withId(5L)
+                .withParentComment(root2)
+                .build();
+        DiscussionComment root2reply2 = DiscussionCommentTestData.defaultDiscussionComment()
+                .withId(6L)
+                .withParentComment(root2)
+                .build();
+
+        return List.of(root1, root2, root1reply1, root1reply2, root2reply1, root2reply2);
+    }
+}

--- a/backend/src/test/java/develup/application/discussion/comment/DiscussionCommentRepliesResponseTest.java
+++ b/backend/src/test/java/develup/application/discussion/comment/DiscussionCommentRepliesResponseTest.java
@@ -1,0 +1,66 @@
+package develup.application.discussion.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import develup.application.member.MemberResponse;
+import develup.domain.discussion.comment.DiscussionComment;
+import develup.support.data.DiscussionCommentTestData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DiscussionCommentRepliesResponseTest {
+
+    public static final MemberResponse EMPTY_MEMBER = new MemberResponse(0L, "", "", "");
+
+    @Test
+    @DisplayName("DiscussionCommentRepliesResponse로 변환한다.")
+    void toDiscussionCommentRepliesResponse() {
+        DiscussionComment rootComment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withId(1L)
+                .build();
+        DiscussionComment reply = DiscussionCommentTestData.defaultDiscussionComment()
+                .withId(2L)
+                .withParentComment(rootComment)
+                .build();
+
+        DiscussionCommentRepliesResponse rootCommentResponse = DiscussionCommentRepliesResponse.of(
+                rootComment,
+                List.of(reply)
+        );
+
+        DiscussionReplyResponse replyResponse = DiscussionReplyResponse.from(reply);
+        assertAll(
+                () -> assertThat(rootCommentResponse.replies()).containsExactly(replyResponse),
+                () -> assertThat(rootCommentResponse.isDeleted()).isFalse()
+        );
+    }
+
+    @Test
+    @DisplayName("DiscussionCommentRepliesResponse로 변환 시 삭제된 댓글인 경우 내용 숨김 처리한다.")
+    void hideContentWhenDeleted() {
+        DiscussionComment rootComment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withId(1L)
+                .withDeletedAt(LocalDateTime.now())
+                .build();
+        DiscussionComment reply = DiscussionCommentTestData.defaultDiscussionComment()
+                .withId(2L)
+                .withParentComment(rootComment)
+                .build();
+
+        DiscussionCommentRepliesResponse rootCommentResponse = DiscussionCommentRepliesResponse.of(
+                rootComment,
+                List.of(reply)
+        );
+
+        DiscussionReplyResponse replyResponse = DiscussionReplyResponse.from(reply);
+        assertAll(
+                () -> assertThat(rootCommentResponse.replies()).containsExactly(replyResponse),
+                () -> assertThat(rootCommentResponse.isDeleted()).isTrue(),
+                () -> assertThat(rootCommentResponse.content()).isEmpty(),
+                () -> assertThat(rootCommentResponse.member()).isEqualTo(EMPTY_MEMBER)
+        );
+    }
+}

--- a/backend/src/test/java/develup/application/discussion/comment/DiscussionCommentServiceTest.java
+++ b/backend/src/test/java/develup/application/discussion/comment/DiscussionCommentServiceTest.java
@@ -1,0 +1,224 @@
+package develup.application.discussion.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.time.LocalDateTime;
+import develup.api.exception.DevelupException;
+import develup.domain.discussion.Discussion;
+import develup.domain.discussion.DiscussionRepository;
+import develup.domain.discussion.comment.DiscussionComment;
+import develup.domain.discussion.comment.DiscussionCommentRepository;
+import develup.domain.member.Member;
+import develup.domain.member.MemberRepository;
+import develup.domain.mission.Mission;
+import develup.domain.mission.MissionRepository;
+import develup.support.IntegrationTestSupport;
+import develup.support.data.DiscussionCommentTestData;
+import develup.support.data.DiscussionTestData;
+import develup.support.data.MemberTestData;
+import develup.support.data.MissionTestData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class DiscussionCommentServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private DiscussionCommentService discussionCommentService;
+
+    @Autowired
+    private DiscussionCommentRepository discussionCommentRepository;
+
+    @Autowired
+    private DiscussionRepository discussionRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Test
+    @DisplayName("댓글을 조회한다.")
+    void getComment() {
+        DiscussionComment discussionComment = createDiscussionComment();
+
+        DiscussionComment foundDiscussionComment = discussionCommentService.getComment(discussionComment.getId());
+
+        assertThat(foundDiscussionComment).isEqualTo(discussionComment);
+    }
+
+    @Test
+    @DisplayName("댓글 조회 시 존재하지 않는 경우 예외가 발생한다.")
+    void getComment_notFound() {
+        Long unknownId = -1L;
+
+        assertThatThrownBy(() -> discussionCommentService.getComment(unknownId))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("존재하지 않는 댓글입니다.");
+    }
+
+    @Test
+    @DisplayName("댓글 조회 시 삭제된 댓글일 경우 예외가 발생한다.")
+    void getCommentFailedWhenDeleted() {
+        Discussion discussion = createDiscussion();
+        Member member = discussion.getMember();
+        DiscussionComment deletedComment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withDiscussion(discussion)
+                .withMember(member)
+                .withDeletedAt(LocalDateTime.now())
+                .build();
+        discussionCommentRepository.save(deletedComment);
+
+        Long commentId = deletedComment.getId();
+        assertThatThrownBy(() -> discussionCommentService.getComment(commentId))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("존재하지 않는 댓글입니다.");
+    }
+
+    @Test
+    @DisplayName("댓글을 추가한다.")
+    void addComment() {
+        Discussion discussion = createDiscussion();
+        Member member = discussion.getMember();
+
+        Long discussionId = discussion.getId();
+        Long memberId = member.getId();
+        DiscussionCommentRequest request = new DiscussionCommentRequest(
+                "댓글입니다.",
+                null
+        );
+        CreateDiscussionCommentResponse response = discussionCommentService.addComment(discussionId, request, memberId);
+
+        assertAll(
+                () -> assertThat(discussionCommentRepository.findAll()).hasSize(1),
+                () -> assertThat(response.parentCommentId()).isNull()
+        );
+    }
+
+    @Test
+    @DisplayName("답글을 추가한다.")
+    void addReply() {
+        DiscussionComment discussionComment = createDiscussionComment();
+        Member member = discussionComment.getMember();
+        Discussion discussion = discussionComment.getDiscussion();
+
+        Long discussionId = discussion.getId();
+        Long memberId = member.getId();
+        DiscussionCommentRequest request = new DiscussionCommentRequest(
+                "답글입니다.",
+                discussionComment.getId()
+        );
+        CreateDiscussionCommentResponse response = discussionCommentService.addComment(discussionId, request, memberId);
+
+        assertAll(
+                () -> assertThat(discussionCommentRepository.findAll()).hasSize(2),
+                () -> assertThat(response.parentCommentId()).isEqualTo(discussionComment.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("댓글 내용을 수정한다.")
+    void updateComment() {
+        DiscussionComment discussionComment = createDiscussionComment();
+        Member member = discussionComment.getMember();
+
+        Long commentId = discussionComment.getId();
+        Long memberId = member.getId();
+        String updatedContent = "수정된 댓글입니다.";
+        UpdateDiscussionCommentRequest request = new UpdateDiscussionCommentRequest(updatedContent);
+        UpdateDiscussionCommentResponse response = discussionCommentService.updateComment(commentId, request, memberId);
+
+        assertAll(
+                () -> assertThat(response.content()).isEqualTo(updatedContent),
+                () -> assertThat(discussionCommentRepository.findById(commentId))
+                        .map(DiscussionComment::getContent)
+                        .hasValue(updatedContent)
+        );
+    }
+
+    @Test
+    @DisplayName("댓글을 수정 시 작성자가 아닌 경우 예외가 발생한다.")
+    void updateComment_notWrittenBy() {
+        DiscussionComment discussionComment = createDiscussionComment();
+
+        Long commentId = discussionComment.getId();
+        Long nonWriterId = -1L;
+        String updatedContent = "수정된 댓글입니다.";
+        UpdateDiscussionCommentRequest request = new UpdateDiscussionCommentRequest(updatedContent);
+
+        assertThatThrownBy(() -> discussionCommentService.updateComment(commentId, request, nonWriterId))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("댓글 작성자가 아닙니다.");
+    }
+
+    @Test
+    @DisplayName("삭제된 댓글의 내용을 수정할 수 없다.")
+    void updateCommentFailedWhenAlreadyDeleted() {
+        DiscussionComment discussionComment = createDiscussionComment();
+        Member member = discussionComment.getMember();
+
+        Long commentId = discussionComment.getId();
+        Long memberId = member.getId();
+        String updatedContent = "수정된 댓글입니다.";
+        UpdateDiscussionCommentRequest request = new UpdateDiscussionCommentRequest(updatedContent);
+
+        discussionCommentService.deleteComment(commentId, memberId);
+
+        assertThatThrownBy(() -> discussionCommentService.updateComment(commentId, request, memberId))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("존재하지 않는 댓글입니다.");
+    }
+
+
+    @Test
+    @DisplayName("댓글을 삭제한다.")
+    void deleteComment() {
+        DiscussionComment discussionComment = createDiscussionComment();
+
+        Long memberId = discussionComment.getMember().getId();
+        Long commentId = discussionComment.getId();
+        discussionCommentService.deleteComment(commentId, memberId);
+
+        assertThat(discussionCommentRepository.findById(commentId))
+                .map(DiscussionComment::isDeleted)
+                .hasValue(true);
+    }
+
+    @Test
+    @DisplayName("댓글을 삭제 시 작성자가 아닌 경우 예외가 발생한다.")
+    void deleteComment_notWrittenBy() {
+        DiscussionComment discussionComment = createDiscussionComment();
+
+        Long nonWriterId = -1L;
+        Long commentId = discussionComment.getId();
+
+        assertThatThrownBy(() -> discussionCommentService.deleteComment(commentId, nonWriterId))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("댓글 작성자가 아닙니다.");
+    }
+
+    private Discussion createDiscussion() {
+        Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMission(mission)
+                .withMember(member)
+                .build();
+
+        return discussionRepository.save(discussion);
+    }
+
+    private DiscussionComment createDiscussionComment() {
+        Discussion discussion = createDiscussion();
+        DiscussionComment discussionComment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withDiscussion(discussion)
+                .withMember(discussion.getMember())
+                .build();
+        discussionCommentRepository.save(discussionComment);
+
+        return discussionComment;
+    }
+}

--- a/backend/src/test/java/develup/domain/discussion/comment/DiscussionCommentRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/discussion/comment/DiscussionCommentRepositoryTest.java
@@ -1,0 +1,122 @@
+package develup.domain.discussion.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import develup.domain.discussion.Discussion;
+import develup.domain.discussion.DiscussionRepository;
+import develup.domain.member.Member;
+import develup.domain.member.MemberRepository;
+import develup.domain.mission.Mission;
+import develup.domain.mission.MissionRepository;
+import develup.support.IntegrationTestSupport;
+import develup.support.data.DiscussionCommentTestData;
+import develup.support.data.DiscussionTestData;
+import develup.support.data.MemberTestData;
+import develup.support.data.MissionTestData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class DiscussionCommentRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private DiscussionRepository discussionRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Autowired
+    private DiscussionCommentRepository discussionCommentRepository;
+
+    @Test
+    @DisplayName("특정 회원이 작성한 댓글 목록을 조회한다.")
+    void getMyComments() {
+        Discussion discussion = createDiscussion();
+        Member member = createMember();
+        List<DiscussionComment> discussionComments = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            DiscussionComment discussionComment = createDiscussionComment(discussion, member);
+            discussionComments.add(discussionComment);
+        }
+        createDiscussionComment();
+
+        List<MyDiscussionComment> myComments = discussionCommentRepository.findAllMyDiscussionComment(member.getId());
+
+        assertThat(myComments)
+                .hasSize(discussionComments.size());
+    }
+
+    @Test
+    @DisplayName("특정 회원이 작성한 댓글 목록을 조회할 때 삭제된 댓글은 제외한다.")
+    void getMyCommentsWithDelete() {
+        Discussion discussion = createDiscussion();
+        Member member = createMember();
+        List<DiscussionComment> discussionComments = new ArrayList<>();
+        for (int i = 0; i < 4; i++) {
+            DiscussionComment discussionComment = createDiscussionComment(discussion, member);
+            discussionComments.add(discussionComment);
+        }
+        createDiscussionComment();
+        createDeletedDiscussionComment(discussion, member);
+
+        List<MyDiscussionComment> myComments = discussionCommentRepository.findAllMyDiscussionComment(member.getId());
+
+        assertThat(myComments)
+                .hasSize(discussionComments.size());
+    }
+
+    private Discussion createDiscussion() {
+        Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMission(mission)
+                .withMember(member)
+                .build();
+
+        return discussionRepository.save(discussion);
+    }
+
+    private DiscussionComment createDiscussionComment() {
+        Discussion discussion = createDiscussion();
+        DiscussionComment discussionComment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withDiscussion(discussion)
+                .withMember(discussion.getMember())
+                .build();
+        discussionCommentRepository.save(discussionComment);
+
+        return discussionComment;
+    }
+
+    private Member createMember() {
+        Member member = MemberTestData.defaultMember().build();
+
+        return memberRepository.save(member);
+    }
+
+    private DiscussionComment createDiscussionComment(Discussion discussion, Member member) {
+        DiscussionComment discussionComment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withDiscussion(discussion)
+                .withMember(member)
+                .build();
+        discussionCommentRepository.save(discussionComment);
+
+        return discussionComment;
+    }
+
+    private DiscussionComment createDeletedDiscussionComment(Discussion discussion, Member member) {
+        DiscussionComment discussionComment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withDiscussion(discussion)
+                .withMember(member)
+                .withDeletedAt(LocalDateTime.now())
+                .build();
+        discussionCommentRepository.save(discussionComment);
+
+        return discussionComment;
+    }
+}

--- a/backend/src/test/java/develup/domain/discussion/comment/DiscussionCommentTest.java
+++ b/backend/src/test/java/develup/domain/discussion/comment/DiscussionCommentTest.java
@@ -1,0 +1,125 @@
+package develup.domain.discussion.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.time.LocalDateTime;
+import develup.api.exception.DevelupException;
+import develup.domain.member.Member;
+import develup.support.data.DiscussionCommentTestData;
+import develup.support.data.MemberTestData;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DiscussionCommentTest {
+
+    @Test
+    @DisplayName("댓글을 생성할 수 있다.")
+    void create() {
+        String content = "댓글입니다.";
+        DiscussionComment comment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withContent(content)
+                .build();
+
+        assertAll(
+                () -> assertThat(comment.getContent()).isEqualTo(content),
+                () -> assertThat(comment.getParentComment()).isNull(),
+                () -> assertThat(comment.getDeletedAt()).isNull()
+        );
+    }
+
+    @Test
+    @DisplayName("댓글 내용을 수정할 수 있다.")
+    void updateContent() {
+        DiscussionComment comment = DiscussionCommentTestData.defaultDiscussionComment().build();
+        String updatedContent = "수정된 댓글입니다.";
+
+        comment.updateContent(updatedContent);
+
+        assertThat(comment.getContent()).isEqualTo(updatedContent);
+    }
+
+    @Test
+    @DisplayName("삭제된 댓글의 내용을 수정할 수 없다.")
+    void updateContentFailedWhenAlreadyDeleted() {
+        DiscussionComment comment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withDeletedAt(LocalDateTime.now())
+                .build();
+        String updatedContent = "수정된 댓글입니다.";
+
+        assertThatThrownBy(() -> comment.updateContent(updatedContent))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("이미 삭제된 댓글입니다.");
+    }
+
+
+    @Test
+    @DisplayName("댓글을 삭제할 수 있다.")
+    void delete() {
+        DiscussionComment comment = DiscussionCommentTestData.defaultDiscussionComment().build();
+
+        comment.delete();
+
+        assertThat(comment.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("삭제된 댓글은 삭제할 수 없다.")
+    void deleteFailedWhenAlreadyDeleted() {
+        DiscussionComment comment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withDeletedAt(LocalDateTime.now())
+                .build();
+
+        assertThatThrownBy(comment::delete)
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("이미 삭제된 댓글입니다.");
+    }
+
+    @Test
+    @DisplayName("댓글에 답글을 달 수 있다.")
+    void reply() {
+        DiscussionComment parentComment = DiscussionCommentTestData.defaultDiscussionComment().build();
+        String content = "답글입니다.";
+        Member member = MemberTestData.defaultMember().build();
+
+        DiscussionComment reply = parentComment.reply(content, member);
+
+        assertAll(
+                () -> assertThat(reply.getContent()).isEqualTo(content),
+                () -> assertThat(reply.getDiscussion()).isEqualTo(parentComment.getDiscussion()),
+                () -> assertThat(reply.getMember()).isEqualTo(member),
+                () -> assertThat(reply.getParentComment()).isEqualTo(parentComment),
+                () -> assertThat(reply.getDeletedAt()).isNull()
+        );
+    }
+
+    @Test
+    @DisplayName("삭제된 댓글에는 답글을 달 수 없다.")
+    void replyFailedWhenAlreadyDeleted() {
+        DiscussionComment parentComment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withDeletedAt(LocalDateTime.now())
+                .build();
+        String content = "답글입니다.";
+        Member member = MemberTestData.defaultMember().build();
+
+        assertThatThrownBy(() -> parentComment.reply(content, member))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("이미 삭제된 댓글입니다.");
+    }
+
+    @Test
+    @DisplayName("답글에는 답글을 달 수 없다.")
+    void replyFailedWhenAlreadyReply() {
+        DiscussionComment rootComment = DiscussionCommentTestData.defaultDiscussionComment().build();
+        DiscussionComment reply = DiscussionCommentTestData.defaultDiscussionComment()
+                .withParentComment(rootComment)
+                .build();
+        String content = "답글에 대한 답글입니다.";
+        Member member = MemberTestData.defaultMember().build();
+
+        assertThatThrownBy(() -> reply.reply(content, member))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("답글에는 답글을 작성할 수 없습니다.");
+    }
+}

--- a/backend/src/test/java/develup/support/data/DiscussionCommentTestData.java
+++ b/backend/src/test/java/develup/support/data/DiscussionCommentTestData.java
@@ -1,0 +1,70 @@
+package develup.support.data;
+
+import java.time.LocalDateTime;
+import develup.domain.discussion.Discussion;
+import develup.domain.discussion.comment.DiscussionComment;
+import develup.domain.member.Member;
+
+public class DiscussionCommentTestData {
+
+    public static DiscussionCommentBuilder defaultDiscussionComment() {
+        return new DiscussionCommentBuilder()
+                .withId(null)
+                .withContent("안녕하세요. 피드백 잘 부탁 드려요.")
+                .withDiscussion(DiscussionTestData.defaultDiscussion().build())
+                .withMember(MemberTestData.defaultMember().build())
+                .withParentComment(null)
+                .withDeletedAt(null);
+    }
+
+    public static class DiscussionCommentBuilder {
+
+        private Long id;
+        private String content;
+        private Discussion discussion;
+        private Member member;
+        private DiscussionComment parentComment;
+        private LocalDateTime deletedAt;
+
+        public DiscussionCommentBuilder withId(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public DiscussionCommentBuilder withContent(String content) {
+            this.content = content;
+            return this;
+        }
+
+        public DiscussionCommentBuilder withDiscussion(Discussion discussion) {
+            this.discussion = discussion;
+            return this;
+        }
+
+        public DiscussionCommentBuilder withMember(Member member) {
+            this.member = member;
+            return this;
+        }
+
+        public DiscussionCommentBuilder withParentComment(DiscussionComment parentComment) {
+            this.parentComment = parentComment;
+            return this;
+        }
+
+        public DiscussionCommentBuilder withDeletedAt(LocalDateTime deletedAt) {
+            this.deletedAt = deletedAt;
+            return this;
+        }
+
+        public DiscussionComment build() {
+            return new DiscussionComment(
+                    id,
+                    content,
+                    discussion,
+                    member,
+                    parentComment,
+                    deletedAt
+            );
+        }
+    }
+}


### PR DESCRIPTION
#### 구현 요약

디스커션 댓글 관련 기능을 구현합니다.

회의에서와는 달리 대시보드의 디스커션 댓글 기능 역시 이 PR 에서 구현했습니다. 그 부분만 빼고 복붙하기 힘들어서요.

SolutionComment 관련 클래스들을 모두 복사한 뒤 DiscussionComment 관련 클래스로 만들었습니다.

이 과정에서 각 클래스 내부에 변수의 일부의 이름 변경이 누락되었을 가능성이 있습니다. 이 부분 중점적으로 리뷰해주시면 됩니다.

#### 연관 이슈
- close #429 
- close #449
- close #445 

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
