### PR TITLE
요청 및 응답 로깅 구현(issue #448)

### DIFF
--- a/backend/src/main/java/develup/api/logging/LoggingFilter.java
+++ b/backend/src/main/java/develup/api/logging/LoggingFilter.java
@@ -49,7 +49,7 @@ public class LoggingFilter extends OncePerRequestFilter {
         saveRequestHeader(cachedRequest);
         printRequestLog();
 
-        addTraceIdToRespone(cachedResponse);
+        addTraceIdToResponse(cachedResponse);
         saveResponseBody(cachedResponse);
         cachedResponse.copyBodyToResponse();
         saveResponseHeader(cachedResponse);
@@ -105,7 +105,7 @@ public class LoggingFilter extends OncePerRequestFilter {
         MDC.put("requestHeaders", headers);
     }
 
-    private void addTraceIdToRespone(HttpServletResponse response) {
+    private void addTraceIdToResponse(HttpServletResponse response) {
         response.addHeader("Trace-Id", MDC.get("traceId"));
     }
 

--- a/backend/src/main/java/develup/api/logging/LoggingFilter.java
+++ b/backend/src/main/java/develup/api/logging/LoggingFilter.java
@@ -40,6 +40,7 @@ public class LoggingFilter extends OncePerRequestFilter {
         saveRequestHeader(cachedRequest);
         printRequestLog();
 
+        addTraceIdToRespone(cachedResponse);
         saveResponseBody(cachedResponse);
         cachedResponse.copyBodyToResponse();
         saveResponseHeader(cachedResponse);
@@ -81,6 +82,10 @@ public class LoggingFilter extends OncePerRequestFilter {
                 .map(headerName -> headerName + " : " + request.getHeader(headerName))
                 .collect(Collectors.joining("\n"));
         MDC.put("requestHeaders", headers);
+    }
+
+    private void addTraceIdToRespone(HttpServletResponse response) {
+        response.addHeader("Trace-Id", MDC.get("traceId"));
     }
 
     private void saveResponseBody(ContentCachingResponseWrapper cachedResponse) {

--- a/backend/src/main/java/develup/api/logging/LoggingFilter.java
+++ b/backend/src/main/java/develup/api/logging/LoggingFilter.java
@@ -73,7 +73,11 @@ public class LoggingFilter extends OncePerRequestFilter {
     }
 
     private void saveQueryString(ContentCachingRequestWrapper cachedRequest) {
-        MDC.put("queryString", cachedRequest.getQueryString());
+        String queryString = "?" + cachedRequest.getQueryString();
+        if (queryString.equals("?null")) {
+            queryString = "";
+        }
+        MDC.put("queryString", queryString);
     }
 
     private void saveRequestHeader(HttpServletRequest request) {
@@ -104,7 +108,7 @@ public class LoggingFilter extends OncePerRequestFilter {
         String template = """
                                 
                 Request
-                {} {}?{}
+                {} {}{}
                 Headers :
                 {}
                 Content :

--- a/backend/src/main/java/develup/api/logging/LoggingFilter.java
+++ b/backend/src/main/java/develup/api/logging/LoggingFilter.java
@@ -1,0 +1,130 @@
+package develup.api.logging;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+@Component
+@Order(1)
+public class LoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(LoggingFilter.class);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        saveTraceId(request);
+
+        ContentCachingRequestWrapper cachedRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper cachedResponse = new ContentCachingResponseWrapper(response);
+
+        saveRequestBody(cachedRequest);
+
+        filterChain.doFilter(cachedRequest, cachedResponse);
+
+        saveRequestMethod(cachedRequest);
+        saveRequestUri(cachedRequest);
+        saveQueryString(cachedRequest);
+        saveRequestHeader(cachedRequest);
+        printRequestLog();
+
+        saveResponseBody(cachedResponse);
+        cachedResponse.copyBodyToResponse();
+        saveResponseHeader(cachedResponse);
+        printResponseLog();
+    }
+
+    private void saveTraceId(HttpServletRequest request) {
+        String header = request.getHeader("X-Request-ID");
+        if (header == null || header.isBlank()) {
+            header = UUID.randomUUID().toString();
+        }
+        MDC.put("traceId", header);
+    }
+
+    private void saveRequestBody(ContentCachingRequestWrapper cachedRequest) {
+        String content = cachedRequest.getContentAsString();
+        if (content.isBlank()) {
+            content = "null";
+        }
+        MDC.put("requestBody", content);
+    }
+
+    private void saveRequestMethod(ContentCachingRequestWrapper cachedRequest) {
+        MDC.put("method", cachedRequest.getMethod());
+    }
+
+    private void saveRequestUri(ContentCachingRequestWrapper cachedRequest) {
+        MDC.put("requestUri", cachedRequest.getRequestURI());
+    }
+
+    private void saveQueryString(ContentCachingRequestWrapper cachedRequest) {
+        MDC.put("queryString", cachedRequest.getQueryString());
+    }
+
+    private void saveRequestHeader(HttpServletRequest request) {
+        String headers = Collections.list(request.getHeaderNames())
+                .stream()
+                .map(headerName -> headerName + " : " + request.getHeader(headerName))
+                .collect(Collectors.joining("\n"));
+        MDC.put("requestHeaders", headers);
+    }
+
+    private void saveResponseBody(ContentCachingResponseWrapper cachedResponse) {
+        MDC.put("responseBody", new String(cachedResponse.getContentAsByteArray()));
+    }
+
+    private void saveResponseHeader(ContentCachingResponseWrapper cachedResponse) {
+        String responseHeader = cachedResponse.getHeaderNames()
+                .stream()
+                .map(headerName -> headerName + " : " + cachedResponse.getHeader(headerName))
+                .collect(Collectors.joining("\n"));
+        MDC.put("responseHeader", responseHeader);
+    }
+
+    private void printRequestLog() {
+        String template = """
+                                
+                Request
+                {} {}?{}
+                Headers :
+                {}
+                Content :
+                {}
+                              
+                """;
+        log.info(
+                template,
+                MDC.get("method"),
+                MDC.get("requestUri"),
+                MDC.get("queryString"),
+                MDC.get("requestHeaders"),
+                MDC.get("requestBody")
+        );
+    }
+
+    private static void printResponseLog() {
+        String responseLogTemplate = """
+                                
+                Response
+                Headers : 
+                {}
+                Content : 
+                {}
+                                
+                """;
+        log.info(responseLogTemplate, MDC.get("responseHeader"), MDC.get("responseBody"));
+    }
+}

--- a/backend/src/main/java/develup/api/logging/LoggingFilter.java
+++ b/backend/src/main/java/develup/api/logging/LoggingFilter.java
@@ -44,6 +44,7 @@ public class LoggingFilter extends OncePerRequestFilter {
         cachedResponse.copyBodyToResponse();
         saveResponseHeader(cachedResponse);
         printResponseLog();
+        MDC.clear();
     }
 
     private void saveTraceId(HttpServletRequest request) {

--- a/backend/src/main/java/develup/api/logging/LoggingFilter.java
+++ b/backend/src/main/java/develup/api/logging/LoggingFilter.java
@@ -121,7 +121,7 @@ public class LoggingFilter extends OncePerRequestFilter {
         );
     }
 
-    private static void printResponseLog() {
+    private void printResponseLog() {
         String responseLogTemplate = """
                                 
                 Response

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -6,7 +6,7 @@
         <encoder>
             <charset>UTF-8</charset>
             <pattern>
-                %d{yyyy-MM-dd HH:mm:ss.SSS} | %t | %highlight(%-5p) | %cyan(%logger{36}) | %m%n
+                %d{yyyy-MM-dd HH:mm:ss.SSS} | %t | [traceId=%X{traceId}] | %highlight(%-5p) | %cyan(%logger{36}) | %m%n
             </pattern>
         </encoder>
     </appender>
@@ -17,7 +17,10 @@
         </http>
         <format>
             <label>
-                <pattern>app=${appName},host=${HOSTNAME},traceID=%X{traceId:-NONE},level=%level</pattern>
+                <pattern>
+                    app=${appName} | host=${HOSTNAME} | %d{yyyy-MM-dd HH:mm:ss.SSS} | %t | [traceId=%X{traceId}] |
+                    %highlight(%-5p) | %cyan(%logger{36}) | %m%n
+                </pattern>
             </label>
             <message>
                 <pattern>${FILE_LOG_PATTERN}</pattern>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <include resource="org/springframework/boot/logging/logback/base.xml"/>
     <springProperty scope="context" name="appName" source="spring.application.name"/>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -18,8 +18,7 @@
         <format>
             <label>
                 <pattern>
-                    %d{yyyy-MM-dd HH:mm:ss.SSS} | %t | traceId=%X{traceId} | %highlight(%-5p) | %cyan(%logger{36}) |
-                    app=${appName} | host=${HOSTNAME} | %m%n
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} | %t | traceId=%X{traceId} | %highlight(%-5p) | %cyan(%logger{36}) | app=${appName} | host=${HOSTNAME} | %m%n
                 </pattern>
             </label>
             <message>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -6,7 +6,7 @@
         <encoder>
             <charset>UTF-8</charset>
             <pattern>
-                %d{yyyy-MM-dd HH:mm:ss.SSS} | %t | [traceId=%X{traceId}] | %highlight(%-5p) | %cyan(%logger{36}) | %m%n
+                %d{yyyy-MM-dd HH:mm:ss.SSS} | %t | traceId=%X{traceId} | %highlight(%-5p) | %cyan(%logger{36}) | %m%n
             </pattern>
         </encoder>
     </appender>
@@ -18,8 +18,8 @@
         <format>
             <label>
                 <pattern>
-                    app=${appName} | host=${HOSTNAME} | %d{yyyy-MM-dd HH:mm:ss.SSS} | %t | [traceId=%X{traceId}] |
-                    %highlight(%-5p) | %cyan(%logger{36}) | %m%n
+                    %d{yyyy-MM-dd HH:mm:ss.SSS} | %t | traceId=%X{traceId} | %highlight(%-5p) | %cyan(%logger{36}) |
+                    app=${appName} | host=${HOSTNAME} | %m%n
                 </pattern>
             </label>
             <message>


### PR DESCRIPTION
#### 구현 요약

HTTP 요청과 응답을 로그로 남기고 이를 추적하기 위한 식별자인 TraceId 를 응답의 헤더 `Trace-Id `로 지정했습니다.

이를 통해 QA 혹은 기타 테스트 상황에서 예상하지 못한 동작이 발생할 경우, 이를 추적하기 수월해집니다. 

추가로 기존에 Loki에 전송되는 로그 포맷과 로컬에서 터미널에 출력되는 로그의 형식이 다른 것을 로컬의 형식으로 통일했습니다.

아래는 이를 적용했을 시 남겨지는 로그입니다.

![image](https://github.com/user-attachments/assets/bb811389-ecca-4dcd-b4b4-d58afbb083a5)

아래는 curl 을 통한 요청 시 응답의 헤더를 포함한 출력 예시입니다.

![image](https://github.com/user-attachments/assets/3700757d-5223-4528-9b35-9e8ba2d95163)


#### 연관 이슈

- close #448 

#### 참고

메인 서버 배포 후 Loki 등에서 잘 수집하는지 확인할 필요가 있습니다.

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
