### PR TITLE
Solution 단건 조회 n + 1 문제 해결(issue #453)

### DIFF
--- a/backend/src/main/java/develup/application/solution/SolutionService.java
+++ b/backend/src/main/java/develup/application/solution/SolutionService.java
@@ -107,7 +107,8 @@ public class SolutionService {
     }
 
     public SolutionResponse getById(Long id) {
-        Solution solution = getSolution(id);
+        Solution solution = solutionRepository.findFetchById(id)
+                .orElseThrow(() -> new DevelupException(ExceptionType.SOLUTION_NOT_FOUND));
 
         return SolutionResponse.from(solution);
     }

--- a/backend/src/main/java/develup/domain/solution/SolutionRepository.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionRepository.java
@@ -32,6 +32,17 @@ public interface SolutionRepository extends JpaRepository<Solution, Long> {
 
     List<Solution> findAllByMember_IdAndStatus(Long memberId, SolutionStatus status);
 
+    @Query("""
+            SELECT DISTINCT s
+            FROM Solution s
+            JOIN FETCH s.member mem
+            JOIN FETCH s.mission m
+            JOIN FETCH m.missionHashTags.hashTags mhts
+            JOIN FETCH mhts.hashTag ht
+            WHERE s.id = :solutionId
+            """)
+    Optional<Solution> findFetchById(Long solutionId);
+
     Optional<Solution> findByMember_IdAndMission_IdAndStatus(Long memberId, Long missionId, SolutionStatus status);
 
     @Query("""


### PR DESCRIPTION
#### 구현 요약

기존 solution 단건 조회 쿼리는 해시태그가 4개라고 가정했을 때, 아래와 같이 8건의 쿼리가 발생합니다.
- solution 조회 쿼리 1
- member 조회 쿼리 1
- mission 조회 쿼리 1
- missionHashTag 조회 쿼리 1
- hashTag 조회 쿼리 4

join fetch를 사용해 1건으로 변경했습니다. 다른 부분도 예기치 못한 쿼리가 발생하는 것으로 보이긴 하나, 솔루션 단건 조회는 빈번히 
사용될 것이라 생각했고, 해시태그에서 발생하는 쿼리 수가 많기 때문에 조치했습니다.

#### 연관 이슈

- close #453

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
