### PR TITLE
나의 디스커션 목록 조회 API 구현 (issue #469)

### DIFF
--- a/backend/src/main/java/develup/api/DiscussionApi.java
+++ b/backend/src/main/java/develup/api/DiscussionApi.java
@@ -60,7 +60,7 @@ public class DiscussionApi {
     }
 
     @GetMapping("/discussions/mine")
-    @Operation(summary = "나의 디스커션 목록 조회 API", description = "내가 제출한 디스커션 목록을 조회합니다.")
+    @Operation(summary = "나의 디스커션 목록 조회 API", description = "내가 작성한 디스커션 목록을 조회합니다.")
     public ResponseEntity<ApiResponse<List<SummarizedDiscussionResponse>>> getMyDiscussions(@Auth Accessor accessor) {
         List<SummarizedDiscussionResponse> response = discussionService.getDiscussionsByMemberId(accessor.id());
 

--- a/backend/src/main/java/develup/api/DiscussionApi.java
+++ b/backend/src/main/java/develup/api/DiscussionApi.java
@@ -58,4 +58,12 @@ public class DiscussionApi {
 
         return ResponseEntity.ok(new ApiResponse<>(response));
     }
+
+    @GetMapping("/discussions/mine")
+    @Operation(summary = "나의 디스커션 목록 조회 API", description = "내가 제출한 디스커션 목록을 조회합니다.")
+    public ResponseEntity<ApiResponse<List<SummarizedDiscussionResponse>>> getMyDiscussions(@Auth Accessor accessor) {
+        List<SummarizedDiscussionResponse> response = discussionService.getDiscussionsByMemberId(accessor.id());
+
+        return ResponseEntity.ok(new ApiResponse<>(response));
+    }
 }

--- a/backend/src/main/java/develup/application/discussion/DiscussionService.java
+++ b/backend/src/main/java/develup/application/discussion/DiscussionService.java
@@ -52,7 +52,15 @@ public class DiscussionService {
     }
 
     public List<SummarizedDiscussionResponse> getSummaries(String mission, String hashTagName) {
-        return discussionRepository.findByMissionAndHashTagName(mission, hashTagName).stream()
+        return discussionRepository.findAllByMissionAndHashTagName(mission, hashTagName).stream()
+                .map(SummarizedDiscussionResponse::from)
+                .toList();
+    }
+
+    public List<SummarizedDiscussionResponse> getDiscussionsByMemberId(Long memberId) {
+        List<Discussion> myDiscussions = discussionRepository.findAllByMember_Id(memberId);
+
+        return myDiscussions.stream()
                 .map(SummarizedDiscussionResponse::from)
                 .toList();
     }

--- a/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
@@ -25,7 +25,7 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
                     AND sht.name = :hashTag
                 ))
             """)
-    List<Discussion> findByMissionAndHashTagName(
+    List<Discussion> findAllByMissionAndHashTagName(
             @Param("mission") String mission,
             @Param("hashTag") String hashTagName
     );
@@ -41,4 +41,15 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
             WHERE d.id = :id
             """)
     Optional<Discussion> findFetchById(Long id);
+
+    @Query("""
+            SELECT d
+            FROM Discussion d
+            JOIN FETCH d.mission m
+            JOIN FETCH d.member me
+            JOIN FETCH d.discussionHashTags.hashTags dhts
+            JOIN FETCH dhts.hashTag ht
+            WHERE me.id = :memberId
+            """)
+    List<Discussion> findAllByMember_Id(Long memberId);
 }

--- a/backend/src/test/java/develup/api/DiscussionApiTest.java
+++ b/backend/src/test/java/develup/api/DiscussionApiTest.java
@@ -100,6 +100,30 @@ public class DiscussionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.mission.url", equalTo("https://github.com/develup-mission/java-smoking")));
     }
 
+    @Test
+    @DisplayName("나의 디스커션 목록을 조회한다.")
+    void getMyDiscussions() throws Exception {
+        List<SummarizedDiscussionResponse> myDiscussions = List.of(
+                SummarizedDiscussionResponse.from(createDiscussion()),
+                SummarizedDiscussionResponse.from(createDiscussion())
+        );
+
+        BDDMockito.given(discussionService.getDiscussionsByMemberId(any()))
+                .willReturn(myDiscussions);
+
+        mockMvc.perform(get("/discussions/mine"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data[0].id", equalTo(1)))
+                .andExpect(jsonPath("$.data[0].title", equalTo("루터회관 흡연단속 구현에 대한 고찰")))
+                .andExpect(jsonPath("$.data[0].mission", equalTo("루터회관 흡연단속")))
+                .andExpect(jsonPath("$.data[0].hashTags[0].id", equalTo(1)))
+                .andExpect(jsonPath("$.data[0].hashTags[0].name", equalTo("JAVA")))
+                .andExpect(jsonPath("$.data[0].member.id", equalTo(1)))
+                .andExpect(jsonPath("$.data[0].member.name", equalTo("tester")))
+                .andExpect(jsonPath("$.data[0].commentCount", equalTo(100)));
+    }
+
     private Discussion createDiscussion() {
         HashTag hashTag = HashTagTestData.defaultHashTag()
                 .withId(1L)

--- a/backend/src/test/java/develup/application/discussion/DiscussionServiceTest.java
+++ b/backend/src/test/java/develup/application/discussion/DiscussionServiceTest.java
@@ -179,6 +179,24 @@ class DiscussionServiceTest extends IntegrationTestSupport {
                 .hasMessage("존재하지 않는 디스커션입니다.");
     }
 
+    @Test
+    @DisplayName("나의 디스커션 리스트를 조회한다.")
+    @Transactional
+    void getDiscussionsByMemberId() {
+        Member member = memberRepository.save(MemberTestData.defaultMember().withId(1L).build());
+        Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMember(member)
+                .withMission(mission)
+                .withHashTags(List.of(hashTag))
+                .build();
+
+        discussionRepository.save(discussion);
+
+        assertThat(discussionService.getDiscussionsByMemberId(member.getId())).hasSize(1);
+    }
+
     private void createDiscussion(Mission mission, HashTag hashTag) {
         Member member = memberRepository.save(MemberTestData.defaultMember().build());
 

--- a/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryTest.java
@@ -1,6 +1,7 @@
 package develup.domain.discussion;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
 import java.util.function.Function;
@@ -44,7 +45,7 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         createDiscussion(mission, hashTag);
         createDiscussion(mission, hashTag);
 
-        List<Discussion> actual = discussionRepository.findByMissionAndHashTagName(
+        List<Discussion> actual = discussionRepository.findAllByMissionAndHashTagName(
                 "all",
                 "all"
         );
@@ -62,7 +63,7 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         createDiscussion(mission, hashTag1);
         createDiscussion(mission, hashTag2);
 
-        List<Discussion> discussions = discussionRepository.findByMissionAndHashTagName(
+        List<Discussion> discussions = discussionRepository.findAllByMissionAndHashTagName(
                 "all",
                 "JAVA"
         );
@@ -84,7 +85,7 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         createDiscussion(mission1, hashTag);
         createDiscussion(mission2, hashTag);
 
-        List<Discussion> discussions = discussionRepository.findByMissionAndHashTagName(
+        List<Discussion> discussions = discussionRepository.findAllByMissionAndHashTagName(
                 "루터회관 흡연단속",
                 "all"
         );
@@ -111,6 +112,38 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         assertThat(discussionRepository.findFetchById(savedDiscussion.getId()))
                 .map(Discussion::getId)
                 .hasValue(savedDiscussion.getId());
+    }
+
+    @Test
+    @DisplayName("멤버 식별자를 통해 디스커션을 조회한다.")
+    @Transactional
+    void findByMember_Id() {
+        Member member1 = memberRepository.save(MemberTestData.defaultMember().withId(1L).build());
+        Member member2 = memberRepository.save(MemberTestData.defaultMember().withId(2L).build());
+        Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
+
+        Discussion discussionByMember1 = DiscussionTestData.defaultDiscussion()
+                .withMission(mission)
+                .withMember(member1)
+                .withHashTags(List.of(hashTag))
+                .build();
+        Discussion discussionByMember2 = DiscussionTestData.defaultDiscussion()
+                .withMission(mission)
+                .withMember(member2)
+                .withHashTags(List.of(hashTag))
+                .build();
+
+        discussionRepository.save(discussionByMember1);
+        discussionRepository.save(discussionByMember2);
+
+        List<Discussion> discussionsByMember1 = discussionRepository.findAllByMember_Id(member1.getId());
+        List<Discussion> discussionsByMember2 = discussionRepository.findAllByMember_Id(member2.getId());
+
+        assertAll(
+                () -> assertThat(discussionsByMember1).hasSize(1),
+                () -> assertThat(discussionsByMember2).hasSize(1)
+        );
     }
 
     private void createDiscussion(Mission mission, HashTag hashTag) {


### PR DESCRIPTION
#### 구현 요약

대시보드 페이지 - 내가 작성한 디스커션 목록 조회 API

`SummarizedDiscussionResponse` 와 응답이 같아서 DTO 재사용 하였습니다.
그런데 추후 디스커션 리스트 조회에서 스크랩 기능이 생길 경우 분리가 필요합니다!

#### 연관 이슈

- close #469 

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
