### PR TITLE
디스커션 리스트 필터링 구현 (issue #487)

### DIFF
--- a/frontend/src/components/DiscussionList/DiscussionListItem.tsx
+++ b/frontend/src/components/DiscussionList/DiscussionListItem.tsx
@@ -13,8 +13,7 @@ export default function DiscussionListItem({
     <S.DiscussionItemContainer>
       <S.ContentWrapper>
         <S.BadgeWrapper>
-          {/* TODO: Badge 색상 변경 필요 @프룬 */}
-          <Badge text={mission} />
+          <Badge text={mission} variant="danger" />
           {hashTags.map((hashTag) => (
             <Badge key={hashTag.id} text={`# ${hashTag.name}`} />
           ))}

--- a/frontend/src/components/DiscussionList/index.tsx
+++ b/frontend/src/components/DiscussionList/index.tsx
@@ -1,14 +1,13 @@
 import * as S from './DiscussionList.styled';
-import useDiscussions from '@/hooks/useDiscussions';
 import DiscussionListItem from './DiscussionListItem';
-import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import type { Discussion } from '@/types';
 
-export default function DiscussionList() {
-  const [mission] = useState<string>('all');
-  const [hashTag] = useState<string>('all');
+interface DiscussionListProps {
+  discussions: Discussion[];
+}
 
-  const { data: discussions } = useDiscussions(mission, hashTag);
+export default function DiscussionList({ discussions }: DiscussionListProps) {
   return (
     <S.DiscussionListContainer>
       {discussions.map((discussion) => (

--- a/frontend/src/components/common/Badge/Badge.styled.ts
+++ b/frontend/src/components/common/Badge/Badge.styled.ts
@@ -1,16 +1,36 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import type { BadgeVariant } from '.';
+import type { DefaultTheme } from 'styled-components/dist/types';
 
 interface BadgeContainerProps {
-  $backgroundColor: string;
-  $fontColor: string;
+  $variant: BadgeVariant;
 }
 
+const getColorStyles = (variant: BadgeVariant, theme: DefaultTheme) => {
+  const variantColorMap = {
+    default: {
+      backgroundColor: theme.colors.primary50,
+      color: theme.colors.black,
+    },
+    danger: {
+      backgroundColor: theme.colors.danger50,
+      color: theme.colors.black,
+    },
+  };
+  const { backgroundColor, color } = variantColorMap[variant];
+
+  return css`
+    background-color: ${backgroundColor};
+    color: ${color};
+  `;
+};
+
 export const BadgeContainer = styled.div<BadgeContainerProps>`
-  color: ${({ $fontColor }) => $fontColor};
-  background-color: ${({ $backgroundColor }) => $backgroundColor};
+  ${(props) => props.theme.font.badge}
+  ${(props) => getColorStyles(props.$variant, props.theme)}
+
   width: fit-content;
   padding: 0.4rem 0.8rem;
   border-radius: 0.4rem;
-  ${(props) => props.theme.font.badge}
   white-space: nowrap;
 `;

--- a/frontend/src/components/common/Badge/index.tsx
+++ b/frontend/src/components/common/Badge/index.tsx
@@ -1,21 +1,14 @@
 import type { HTMLAttributes } from 'react';
 import * as S from './Badge.styled';
+import type { BADGE_VARIANTS } from '@/constants/variants';
+
+export type BadgeVariant = keyof typeof BADGE_VARIANTS;
 
 interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
   text: string;
-  fontColor?: string;
-  backgroundColor?: string;
+  variant?: BadgeVariant;
 }
 
-export default function Badge({
-  text,
-  fontColor = 'black',
-  // backgroundColor = 'var(--primary-100)',
-  backgroundColor = '#C4C9ED', // 임시입니다 @프룬
-}: BadgeProps) {
-  return (
-    <S.BadgeContainer $fontColor={fontColor} $backgroundColor={backgroundColor}>
-      {text}
-    </S.BadgeContainer>
-  );
+export default function Badge({ text, variant = 'default' }: BadgeProps) {
+  return <S.BadgeContainer $variant={variant}>{text}</S.BadgeContainer>;
 }

--- a/frontend/src/components/common/TagButton/TagButton.styled.ts
+++ b/frontend/src/components/common/TagButton/TagButton.styled.ts
@@ -12,17 +12,20 @@ const getColorStyles = (variant: TagButtonVariant, isSelected: boolean, theme: D
     default: {
       default: isSelected ? theme.colors.primary100 : theme.colors.primary50,
       hover: isSelected ? theme.colors.primary200 : theme.colors.primary100,
+      color: theme.colors.black,
     },
     danger: {
       default: isSelected ? theme.colors.danger100 : theme.colors.danger50,
       hover: isSelected ? theme.colors.danger200 : theme.colors.danger100,
+      color: theme.colors.black,
     },
   };
 
-  const { default: defaultColor, hover: hoverColor } = variantColorMap[variant];
+  const { default: defaultColor, hover: hoverColor, color } = variantColorMap[variant];
 
   return css`
     background-color: ${defaultColor};
+    color: ${color};
     &:hover {
       background-color: ${hoverColor};
     }
@@ -31,7 +34,6 @@ const getColorStyles = (variant: TagButtonVariant, isSelected: boolean, theme: D
 
 export const Button = styled.button<ButtonProps>`
   ${(props) => getColorStyles(props.$variant, props.$isSelected, props.theme)}
-  color: var(--black-color);
   transition: 0.2s;
 
   padding: 1rem 1.6rem;

--- a/frontend/src/components/common/TagButton/TagButton.styled.ts
+++ b/frontend/src/components/common/TagButton/TagButton.styled.ts
@@ -9,7 +9,7 @@ interface ButtonProps {
 
 const getColorStyles = (variant: TagButtonVariant, isSelected: boolean, theme: DefaultTheme) => {
   const variantColorMap = {
-    primary: {
+    default: {
       default: isSelected ? theme.colors.primary100 : theme.colors.primary50,
       hover: isSelected ? theme.colors.primary200 : theme.colors.primary100,
     },

--- a/frontend/src/components/common/TagButton/index.tsx
+++ b/frontend/src/components/common/TagButton/index.tsx
@@ -11,7 +11,7 @@ interface TagButtonProps extends HTMLAttributes<HTMLButtonElement> {
 
 export default function TagButton({
   isSelected = false,
-  variant = 'primary',
+  variant = 'default',
   children,
   ...props
 }: PropsWithChildren<TagButtonProps>) {

--- a/frontend/src/components/common/TagMultipleList/index.tsx
+++ b/frontend/src/components/common/TagMultipleList/index.tsx
@@ -13,7 +13,7 @@ export default function TagMultipleList<T extends { id: number }>({
   tags,
   selectedTags,
   setSelectedTags,
-  variant = 'primary',
+  variant = 'default',
   keyName,
 }: TagMultipleListProps<T>) {
   const handleSelectedTags = (tag: T) => {

--- a/frontend/src/constants/variants.ts
+++ b/frontend/src/constants/variants.ts
@@ -13,3 +13,8 @@ export const TAG_BUTTON_VARIANTS = {
   default: 'primary',
   danger: 'danger',
 } as const;
+
+export const BADGE_VARIANTS = {
+  default: 'primary',
+  danger: 'danger',
+} as const;

--- a/frontend/src/constants/variants.ts
+++ b/frontend/src/constants/variants.ts
@@ -10,6 +10,6 @@ export const BUTTON_SIZE = {
 } as const;
 
 export const TAG_BUTTON_VARIANTS = {
-  primary: 'primary',
+  default: 'primary',
   danger: 'danger',
 } as const;

--- a/frontend/src/pages/DiscussionListPage/DiscussionListPage.styled.ts
+++ b/frontend/src/pages/DiscussionListPage/DiscussionListPage.styled.ts
@@ -12,3 +12,9 @@ export const DiscussionListPageContainer = styled.div`
 export const DiscussionListTitle = styled.h1`
   ${(props) => props.theme.font.heading1}
 `;
+
+export const TagListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 2.8rem;
+`;

--- a/frontend/src/pages/DiscussionListPage/index.tsx
+++ b/frontend/src/pages/DiscussionListPage/index.tsx
@@ -23,18 +23,21 @@ export default function DiscussionListPage() {
   return (
     <S.DiscussionListPageContainer>
       <S.DiscussionListTitle>💬 Discussion</S.DiscussionListTitle>
-      <TagList
-        tags={allMissions}
-        setSelectedTag={setSelectedMission}
-        selectedTag={selectedMission}
-        keyName="title"
-      />
-      <TagList
-        tags={allHashTags}
-        setSelectedTag={setSelectedHashTag}
-        selectedTag={selectedHashTag}
-        keyName="name"
-      />
+      <S.TagListWrapper>
+        <TagList
+          tags={allMissions}
+          setSelectedTag={setSelectedMission}
+          selectedTag={selectedMission}
+          keyName="title"
+          variant="danger"
+        />
+        <TagList
+          tags={allHashTags}
+          setSelectedTag={setSelectedHashTag}
+          selectedTag={selectedHashTag}
+          keyName="name"
+        />
+      </S.TagListWrapper>
       <DiscussionList discussions={discussions} />
     </S.DiscussionListPageContainer>
   );

--- a/frontend/src/pages/DiscussionListPage/index.tsx
+++ b/frontend/src/pages/DiscussionListPage/index.tsx
@@ -1,11 +1,41 @@
 import DiscussionList from '@/components/DiscussionList';
 import * as S from './DiscussionListPage.styled';
+import { useState } from 'react';
+import useDiscussions from '@/hooks/useDiscussions';
+import TagList from '@/components/common/TagList';
+import useHashTags from '@/hooks/useHashTags';
+import type { HashTag } from '@/types';
+import useMissions from '@/hooks/useMissions';
+
+interface SelectedMissionType {
+  id: number;
+  title: string;
+}
 
 export default function DiscussionListPage() {
+  const [selectedMission, setSelectedMission] = useState<SelectedMissionType | null>(null);
+  const [selectedHashTag, setSelectedHashTag] = useState<HashTag | null>(null);
+
+  const { data: discussions } = useDiscussions(selectedMission?.title, selectedHashTag?.name);
+  const { data: allHashTags } = useHashTags();
+  const { data: allMissions } = useMissions(selectedHashTag?.name); // TODO: 미션 필터링용 미션 리스트 API 나오면 변경 필요
+
   return (
     <S.DiscussionListPageContainer>
       <S.DiscussionListTitle>💬 Discussion</S.DiscussionListTitle>
-      <DiscussionList />
+      <TagList
+        tags={allMissions}
+        setSelectedTag={setSelectedMission}
+        selectedTag={selectedMission}
+        keyName="title"
+      />
+      <TagList
+        tags={allHashTags}
+        setSelectedTag={setSelectedHashTag}
+        selectedTag={selectedHashTag}
+        keyName="name"
+      />
+      <DiscussionList discussions={discussions} />
     </S.DiscussionListPageContainer>
   );
 }

--- a/frontend/src/pages/DiscussionListPage/index.tsx
+++ b/frontend/src/pages/DiscussionListPage/index.tsx
@@ -18,7 +18,7 @@ export default function DiscussionListPage() {
 
   const { data: discussions } = useDiscussions(selectedMission?.title, selectedHashTag?.name);
   const { data: allHashTags } = useHashTags();
-  const { data: allMissions } = useMissions(selectedHashTag?.name); // TODO: 미션 필터링용 미션 리스트 API 나오면 변경 필요
+  const { data: allMissions } = useMissions(); // TODO: 미션 필터링용 미션 리스트 API 나오면 변경 필요
 
   return (
     <S.DiscussionListPageContainer>

--- a/frontend/src/pages/MissionListPage/index.tsx
+++ b/frontend/src/pages/MissionListPage/index.tsx
@@ -4,9 +4,10 @@ import useMissions from '@/hooks/useMissions';
 import useHashTags from '@/hooks/useHashTags';
 import TagList from '@/components/common/TagList';
 import { useState } from 'react';
+import type { HashTag } from '@/types';
 
 export default function MissionListPage() {
-  const [selectedHashTag, setSelectedHashTag] = useState<{ id: number, name: string }|null>(null);
+  const [selectedHashTag, setSelectedHashTag] = useState<HashTag | null>(null);
   const { data: allMissions } = useMissions(selectedHashTag?.name);
   const { data: allHashTags } = useHashTags();
 


### PR DESCRIPTION
#### 구현 요약

1. 디스커션 리스트 필터링을 구현했습니다.

https://github.com/user-attachments/assets/c1a1d270-1241-4199-bc6a-59995dd8bb5d

2. Badge 색상이 두 종류가 되어 props를 variant로 변경했습니다.
```tsx
// 기존
interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
  text: string;
  fontColor?: string;
  backgroundColor?: string;
}

export default function Badge({
  text,
  fontColor = 'black',
  // backgroundColor = 'var(--primary-100)',
  backgroundColor = '#C4C9ED',
}: BadgeProps) {
  // ...
}
```
```tsx
// 변경 후
interface BadgeProps extends HTMLAttributes<HTMLDivElement> {
  text: string;
  variant?: BadgeVariant;
}

export default function Badge({ text, variant = 'default' }: BadgeProps) {}
```


#### 연관 이슈

- close #487

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
