### PR TITLE
디스커션 수정 기능 구현 (issue #472)

### DIFF
--- a/backend/src/main/java/develup/api/DiscussionApi.java
+++ b/backend/src/main/java/develup/api/DiscussionApi.java
@@ -9,12 +9,14 @@ import develup.application.discussion.DiscussionReadService;
 import develup.application.discussion.DiscussionResponse;
 import develup.application.discussion.DiscussionWriteService;
 import develup.application.discussion.SummarizedDiscussionResponse;
+import develup.application.discussion.UpdateDiscussionRequest;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -55,6 +57,17 @@ public class DiscussionApi {
             @Valid @RequestBody CreateDiscussionRequest request
     ) {
         DiscussionResponse response = discussionWriteService.create(accessor.id(), request);
+
+        return ResponseEntity.ok(new ApiResponse<>(response));
+    }
+
+    @PatchMapping("/discussions")
+    @Operation(summary = "디스커션 수정 API", description = "디스커션을 수정합니다.")
+    public ResponseEntity<ApiResponse<DiscussionResponse>> updateDiscussion(
+            @Auth Accessor accessor,
+            @Valid @RequestBody UpdateDiscussionRequest request
+    ) {
+        DiscussionResponse response = discussionWriteService.update(accessor.id(), request);
 
         return ResponseEntity.ok(new ApiResponse<>(response));
     }

--- a/backend/src/main/java/develup/api/exception/ExceptionType.java
+++ b/backend/src/main/java/develup/api/exception/ExceptionType.java
@@ -32,6 +32,8 @@ public enum ExceptionType {
     DUPLICATED_HASHTAG(HttpStatus.BAD_REQUEST, "중복된 해시태그입니다."),
     HASHTAG_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 해시태그입니다."),
     DISCUSSION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 디스커션입니다."),
+    DISCUSSION_NOT_WRITTEN_BY_MEMBER(HttpStatus.FORBIDDEN, "디스커션 작성자가 아닙니다."),
+
     ;
 
     private final HttpStatus status;

--- a/backend/src/main/java/develup/application/discussion/DiscussionWriteService.java
+++ b/backend/src/main/java/develup/application/discussion/DiscussionWriteService.java
@@ -65,7 +65,7 @@ public class DiscussionWriteService {
     }
 
     private void updateMissionIfNeeded(UpdateDiscussionRequest request, Discussion discussion) {
-        if (discussion.isNotSameMission(request.missionId())) {
+        if (request.missionId() != null && discussion.isNotSameMission(request.missionId())) {
             Mission mission = getMission(request.missionId());
             discussion.updateMission(mission);
         }

--- a/backend/src/main/java/develup/application/discussion/DiscussionWriteService.java
+++ b/backend/src/main/java/develup/application/discussion/DiscussionWriteService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DiscussionWriteService {
 
     private final DiscussionRepository discussionRepository;
+    private final DiscussionReadService discussionReadService;
     private final MemberReadService memberReadService;
     private final MissionReadService missionReadService;
     private final HashTagRepository hashTagRepository;
@@ -39,6 +40,42 @@ public class DiscussionWriteService {
         ));
 
         return createDiscussionResponse(discussion);
+    }
+
+    public DiscussionResponse update(
+            Long memberId,
+            UpdateDiscussionRequest request
+    ) {
+        Discussion discussion = discussionReadService.getDiscussion(request.discussionId());
+
+        validateDiscussionOwner(memberId, discussion);
+
+        updateMissionIfNeeded(request, discussion);
+        updateHashTagsIfNeeded(request, discussion);
+
+        discussion.updateTitleAndContent(request.title(), request.content());
+
+        return createDiscussionResponse(discussion);
+    }
+
+    private void validateDiscussionOwner(Long memberId, Discussion discussion) {
+        if (discussion.isNotWrittenBy(memberId)) {
+            throw new DevelupException(ExceptionType.DISCUSSION_NOT_WRITTEN_BY_MEMBER);
+        }
+    }
+
+    private void updateMissionIfNeeded(UpdateDiscussionRequest request, Discussion discussion) {
+        if (discussion.isNotSameMission(request.missionId())) {
+            Mission mission = getMission(request.missionId());
+            discussion.updateMission(mission);
+        }
+    }
+
+    private void updateHashTagsIfNeeded(UpdateDiscussionRequest request, Discussion discussion) {
+        if (discussion.isNotSameHashTags(request.hashTagIds())) {
+            List<HashTag> hashTags = getHashTags(request.hashTagIds());
+            discussion.updateHashTags(hashTags);
+        }
     }
 
     private Mission getMission(Long missionId) {

--- a/backend/src/main/java/develup/application/discussion/UpdateDiscussionRequest.java
+++ b/backend/src/main/java/develup/application/discussion/UpdateDiscussionRequest.java
@@ -1,0 +1,15 @@
+package develup.application.discussion;
+
+import java.util.List;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record UpdateDiscussionRequest(
+        @NotNull @Positive Long discussionId,
+        @NotBlank String title,
+        @NotBlank String content,
+        Long missionId,
+        @NotNull List<Long> hashTagIds
+) {
+}

--- a/backend/src/main/java/develup/domain/discussion/Discussion.java
+++ b/backend/src/main/java/develup/domain/discussion/Discussion.java
@@ -69,6 +69,9 @@ public class Discussion extends CreatedAtAuditableEntity {
     }
 
     public boolean isNotSameMission(Long missionId) {
+        if (this.mission == null) {
+            return true;
+        }
         return !mission.getId().equals(missionId);
     }
 

--- a/backend/src/main/java/develup/domain/discussion/Discussion.java
+++ b/backend/src/main/java/develup/domain/discussion/Discussion.java
@@ -84,7 +84,7 @@ public class Discussion extends CreatedAtAuditableEntity {
     }
 
     public void updateTitleAndContent(String title, String content) {
-        this.title = new Title(title);
+        this.title = new DiscussionTitle(title);
         this.content = content;
     }
 

--- a/backend/src/main/java/develup/domain/discussion/Discussion.java
+++ b/backend/src/main/java/develup/domain/discussion/Discussion.java
@@ -64,6 +64,31 @@ public class Discussion extends CreatedAtAuditableEntity {
         this.discussionHashTags = new DiscussionHashTags(this, hashTags);
     }
 
+    public boolean isNotWrittenBy(Long memberId) {
+        return !member.getId().equals(memberId);
+    }
+
+    public boolean isNotSameMission(Long missionId) {
+        return !mission.getId().equals(missionId);
+    }
+
+    public boolean isNotSameHashTags(List<Long> hashTagIds) {
+        return discussionHashTags.isNotSameHashTags(hashTagIds);
+    }
+
+    public void updateMission(Mission mission) {
+        this.mission = mission;
+    }
+
+    public void updateTitleAndContent(String title, String content) {
+        this.title = new Title(title);
+        this.content = content;
+    }
+
+    public void updateHashTags(List<HashTag> hashTags) {
+        this.discussionHashTags = new DiscussionHashTags(this, hashTags);
+    }
+
     public String getTitle() {
         return title.getValue();
     }

--- a/backend/src/main/java/develup/domain/discussion/DiscussionHashTags.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionHashTags.java
@@ -41,6 +41,15 @@ class DiscussionHashTags {
                 .toList();
     }
 
+    public boolean isNotSameHashTags(List<Long> hashTagIds) {
+        List<Long> currentHashTagIds = hashTags.stream()
+                .map(DiscussionHashTag::getHashTag)
+                .map(HashTag::getId)
+                .toList();
+
+        return !currentHashTagIds.equals(hashTagIds);
+    }
+
     public Set<DiscussionHashTag> getHashTags() {
         return Collections.unmodifiableSet(hashTags);
     }

--- a/backend/src/test/java/develup/api/DiscussionApiTest.java
+++ b/backend/src/test/java/develup/api/DiscussionApiTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -14,6 +15,7 @@ import java.util.List;
 import develup.application.discussion.CreateDiscussionRequest;
 import develup.application.discussion.DiscussionResponse;
 import develup.application.discussion.SummarizedDiscussionResponse;
+import develup.application.discussion.UpdateDiscussionRequest;
 import develup.application.hashtag.HashTagResponse;
 import develup.application.member.MemberResponse;
 import develup.domain.discussion.Discussion;
@@ -140,6 +142,37 @@ public class DiscussionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data[0].member.name", equalTo("tester")))
                 .andExpect(jsonPath("$.data[0].commentCount", equalTo(100)))
                 .andExpect(jsonPath("$.data[0].createdAt").exists());
+    }
+
+    @Test
+    @DisplayName("디스커션을 수정한다.")
+    void updateDiscussion() throws Exception {
+        DiscussionResponse response = DiscussionResponse.from(createDiscussion());
+        UpdateDiscussionRequest request = new UpdateDiscussionRequest(
+                1L,
+                "title",
+                "content",
+                1L,
+                List.of(1L)
+        );
+        BDDMockito.given(discussionWriteService.update(any(), any()))
+                .willReturn(response);
+
+        mockMvc.perform(patch("/discussions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.id", equalTo(1)))
+                .andExpect(jsonPath("$.data.title", equalTo("루터회관 흡연단속 구현에 대한 고찰")))
+                .andExpect(jsonPath("$.data.content", equalTo("루터회관 흡연단속을 구현하면서 느낀 점을 공유합니다.")))
+                .andExpect(jsonPath("$.data.mission.id", equalTo(1)))
+                .andExpect(jsonPath("$.data.mission.title", equalTo("루터회관 흡연단속")))
+                .andExpect(jsonPath("$.data.mission.summary", equalTo("담배피다 걸린 행성이를 위한 벌금 계산 미션")))
+                .andExpect(jsonPath("$.data.mission.thumbnail", equalTo("https://thumbnail.com/1.png")))
+                .andExpect(jsonPath("$.data.mission.url", equalTo("https://github.com/develup-mission/java-smoking")))
+                .andExpect(jsonPath("$.data.hashTags[0].id", equalTo(1)))
+                .andExpect(jsonPath("$.data.hashTags[0].name", equalTo("JAVA")));
     }
 
     private Discussion createDiscussion() {

--- a/backend/src/test/java/develup/application/discussion/DiscussionWriteServiceTest.java
+++ b/backend/src/test/java/develup/application/discussion/DiscussionWriteServiceTest.java
@@ -8,21 +8,32 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
 import develup.api.exception.DevelupException;
+import develup.application.hashtag.HashTagResponse;
+import develup.domain.discussion.Discussion;
+import develup.domain.discussion.DiscussionRepository;
+import develup.domain.hashtag.HashTag;
 import develup.domain.hashtag.HashTagRepository;
+import develup.domain.member.Member;
 import develup.domain.member.MemberRepository;
+import develup.domain.mission.Mission;
 import develup.domain.mission.MissionRepository;
 import develup.support.IntegrationTestSupport;
+import develup.support.data.DiscussionTestData;
 import develup.support.data.HashTagTestData;
 import develup.support.data.MemberTestData;
 import develup.support.data.MissionTestData;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 class DiscussionWriteServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private DiscussionWriteService discussionWriteService;
+
+    @Autowired
+    private DiscussionRepository discussionRepository;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -137,5 +148,91 @@ class DiscussionWriteServiceTest extends IntegrationTestSupport {
         assertThatThrownBy(() -> discussionWriteService.create(memberId, request))
                 .isInstanceOf(DevelupException.class)
                 .hasMessage("존재하지 않는 해시태그입니다.");
+    }
+
+    @Test
+    @DisplayName("디스커션을 수정한다.")
+    @Transactional
+    void updateDiscussion() {
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
+        Discussion discussion = discussionRepository.save(DiscussionTestData.defaultDiscussion()
+                .withMember(member)
+                .withMission(mission)
+                .withHashTags(List.of(hashTag))
+                .build());
+
+        Long newMissionId = missionRepository.save(MissionTestData.defaultMission().build()).getId();
+        Long newHashTagId = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("hashTag").build()).getId();
+
+        UpdateDiscussionRequest request =
+                new UpdateDiscussionRequest(discussion.getId(), "title", "content", newMissionId, List.of(newHashTagId));
+
+        DiscussionResponse response = discussionWriteService.update(member.getId(), request);
+
+        assertAll(
+                () -> assertThat(response.id()).isEqualTo(discussion.getId()),
+                () -> assertThat(response.title()).isEqualTo("title"),
+                () -> assertThat(response.content()).isEqualTo("content"),
+                () -> assertThat(response.mission().id()).isEqualTo(newMissionId),
+                () -> assertThat(response.hashTags()).containsExactly(new HashTagResponse(newHashTagId, "hashTag"))
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 디스커션을 수정 시도하면 예외가 발생한다.")
+    @Transactional
+    void updateDiscussionWithUnknownDiscussion() {
+        Long unknownDiscussionId = 100L;
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
+        discussionRepository.save(DiscussionTestData.defaultDiscussion()
+                .withMember(member)
+                .withMission(mission)
+                .withHashTags(List.of(hashTag))
+                .build());
+
+        UpdateDiscussionRequest request =
+                new UpdateDiscussionRequest(unknownDiscussionId, "title", "content", mission.getId(), List.of(hashTag.getId()));
+
+        assertThatThrownBy(() -> discussionWriteService.update(member.getId(), request))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("존재하지 않는 디스커션입니다.");
+    }
+
+    @Test
+    @DisplayName("디스커션 작성자가 아닌 사용자가 디스커션을 수정하면 예외가 발생한다.")
+    @Transactional
+    void updateDiscussionWithNotOwner() {
+        Long unknownMemberId = -1L;
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
+        Discussion discussion = discussionRepository.save(DiscussionTestData.defaultDiscussion()
+                .withMember(member)
+                .withMission(mission)
+                .withHashTags(List.of(hashTag))
+                .build());
+
+        UpdateDiscussionRequest request =
+                new UpdateDiscussionRequest(discussion.getId(), "title", "content", 1L, List.of(1L));
+
+        assertThatThrownBy(() -> discussionWriteService.update(unknownMemberId, request))
+                .isInstanceOf(DevelupException.class)
+                .hasMessage("디스커션 작성자가 아닙니다.");
+    }
+
+    private void createDiscussion(Mission mission, HashTag hashTag) {
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMission(mission)
+                .withMember(member)
+                .withHashTags(List.of(hashTag))
+                .build();
+
+        discussionRepository.save(discussion);
     }
 }

--- a/backend/src/test/java/develup/domain/discussion/DiscussionTest.java
+++ b/backend/src/test/java/develup/domain/discussion/DiscussionTest.java
@@ -2,12 +2,18 @@ package develup.domain.discussion;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.ArrayList;
 import java.util.List;
 import develup.domain.hashtag.HashTag;
+import develup.domain.member.Member;
+import develup.domain.mission.Mission;
 import develup.support.data.DiscussionTestData;
 import develup.support.data.HashTagTestData;
+import develup.support.data.MemberTestData;
+import develup.support.data.MissionTestData;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -39,5 +45,56 @@ class DiscussionTest {
                 .build();
 
         assertThat(discussion.getHashTags()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("디스커션 작성자가 아니면 true를 맞으면 false를 반환한다.")
+    void isNotWrittenBy() {
+        Member member = MemberTestData.defaultMember()
+                .withId(1L)
+                .build();
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMember(member)
+                .build();
+
+        assertAll(
+                () -> assertThat(discussion.isNotWrittenBy(2L)).isTrue(),
+                () -> assertThat(discussion.isNotWrittenBy(member.getId())).isFalse()
+        );
+    }
+
+    @Test
+    @DisplayName("동일한 미션이 아니면 true를 동일한 미션이면 false를 반환한다.")
+    void isNotSameMission() {
+        Mission mission = MissionTestData.defaultMission()
+                .withId(1L)
+                .build();
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMission(mission)
+                .build();
+
+        assertAll(
+                () -> assertThat(discussion.isNotSameMission(2L)).isTrue(),
+                () -> assertThat(discussion.isNotSameMission(mission.getId())).isFalse()
+        );
+    }
+
+    @Test
+    @DisplayName("완전히 동일한 해시 태그이면 false를 아니면 true를 반환한다.")
+    void isNotSameHashTags() {
+        HashTag hashTag1 = HashTagTestData.defaultHashTag()
+                .withId(1L)
+                .build();
+        HashTag hashTag2 = HashTagTestData.defaultHashTag()
+                .withId(2L)
+                .build();
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withHashTags(List.of(hashTag1, hashTag2))
+                .build();
+
+        assertAll(
+                () -> assertThat(discussion.isNotSameHashTags(List.of(1L))).isTrue(),
+                () -> assertThat(discussion.isNotSameHashTags(List.of(hashTag1.getId(), hashTag2.getId()))).isFalse()
+        );
     }
 }


### PR DESCRIPTION
#### 구현 요약

수정을 구현하며 고려한 부분은 수정 해야할 포인트가 여러 군데인데,
Mission과 HashTag의 경우 id로 비교해서 같은 경우 굳이 업데이트 될 필요가 없다고 생각했습니다.
비교하지 않고 바로 업데이트하면 로직이 간단해지긴 하지만 DB 조회가 필요하기 때문입니다.
이 부분이 불필요하다고 생각하면 알려주세요.

그리고 영속성 문제로 테스트 메서드에 `@Transactional`을 붙여주지 않으면 Discussion 생성 과정에서 테스트가 실패합니다.
(이 부분은 이전에도 논의가 나왔었던 것 같아요 하지만 잘 기억나지 않아서 다시 언급합니다. ^^;;)
`DiscussionHashTags`의 `cascade = CascadeType.PERSIST`를 없애주면 해결이 되는데 이걸 유지하고 테스트 메서드에 `@Transactional`을 다는게 나을지 `cascade = CascadeType.PERSIST`을 없앨 다른 방법을 찾는게 나을지 논의해보았으면 합니다.

그리고 수정 시 `findFetchById` 메서드로 Discussion을 찾으려고 시도하면 조회가 안됩니다. 😅
우선 `findById`를 사용하도록 해두었는데 어느 부분이 문제인지 정확하게 찾을 수 없어서 같이 논의해보았으면 합니다!

#### 연관 이슈

- close #472

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
