### PR TITLE
디스커션 디테일 페이지 태그가 두 개 보여지는 오류 해결 (issue #494)

### DIFF
--- a/frontend/src/pages/DiscussionDetailPage/DiscussionDetailHeader.tsx
+++ b/frontend/src/pages/DiscussionDetailPage/DiscussionDetailHeader.tsx
@@ -25,9 +25,6 @@ export default function DiscussionDetailHeader({ discussion }: DiscussionDetailH
             </S.HashTagWrapper>
           </S.DiscussionDetailInfo>
         </S.HeaderLeftArea>
-        <S.HashTagWrapper>
-          {hashTags && hashTags.map((tag) => <TagButton key={tag.id}># {tag.name}</TagButton>)}
-        </S.HashTagWrapper>
       </S.ThumbnailWrapper>
     </S.DiscussionDetailHeaderContainer>
   );


### PR DESCRIPTION
#### 구현 요약

디스커션 디테일 페이지에서 태그가 두 개 보여지는 오류를 해결합니다.

#### 연관 이슈

close #494

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
