### PR TITLE
디스커션 작성하기 버튼 추가 (issue #497)

### DIFF
--- a/frontend/src/components/DiscussionList/DiscussionList.styled.ts
+++ b/frontend/src/components/DiscussionList/DiscussionList.styled.ts
@@ -1,13 +1,15 @@
 import styled from 'styled-components';
 import CommentCount from '@/assets/images/comment-count.svg';
 
-export const DiscussionListContainer = styled.div`
+// Content
+
+export const ContentContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2.5rem;
 `;
 
-export const DiscussionItemContainer = styled.div`
+export const ItemContainer = styled.div`
   background-color: ${(props) => props.theme.colors.white};
 
   display: flex;
@@ -48,7 +50,7 @@ export const WriterImg = styled.img`
   max-height: 4.2rem;
 `;
 
-export const DiscussionRight = styled.div`
+export const ItemRight = styled.div`
   display: flex;
   align-items: center;
   gap: 1.7rem;
@@ -66,4 +68,16 @@ export const CommentWrapper = styled.div`
 export const CommentCountIcon = styled(CommentCount)`
   width: 1.4rem;
   height: 1.4rem;
+`;
+
+// Header
+
+export const HeaderTitleWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+export const HeaderTitle = styled.h1`
+  ${(props) => props.theme.font.heading1}
 `;

--- a/frontend/src/components/DiscussionList/DiscussionListContent.tsx
+++ b/frontend/src/components/DiscussionList/DiscussionListContent.tsx
@@ -4,13 +4,13 @@ import DiscussionListItem from './DiscussionListItem';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
-export default function DiscussionList() {
+export default function DiscussionListContent() {
   const [mission] = useState<string>('all');
   const [hashTag] = useState<string>('all');
 
   const { data: discussions } = useDiscussions(mission, hashTag);
   return (
-    <S.DiscussionListContainer>
+    <S.ContentContainer>
       {discussions.map((discussion) => (
         <Link key={discussion.id} to={`/discussions/${discussion.id}`}>
           <DiscussionListItem
@@ -22,6 +22,6 @@ export default function DiscussionList() {
           />
         </Link>
       ))}
-    </S.DiscussionListContainer>
+    </S.ContentContainer>
   );
 }

--- a/frontend/src/components/DiscussionList/DiscussionListHeader.tsx
+++ b/frontend/src/components/DiscussionList/DiscussionListHeader.tsx
@@ -6,14 +6,14 @@ import { ROUTES } from '@/constants/routes';
 export default function DiscussionListHeader() {
   const navigate = useNavigate();
 
-  const handleNavigate = () => {
+  const handleToSubmitDiscussion = () => {
     navigate(ROUTES.submitDiscussion);
   };
 
   return (
     <S.HeaderTitleWrapper>
       <S.HeaderTitle>💬 Discussion</S.HeaderTitle>
-      <Button variant="primary" onClick={handleNavigate}>
+      <Button variant="primary" onClick={handleToSubmitDiscussion}>
         작성하기
       </Button>
     </S.HeaderTitleWrapper>

--- a/frontend/src/components/DiscussionList/DiscussionListHeader.tsx
+++ b/frontend/src/components/DiscussionList/DiscussionListHeader.tsx
@@ -1,0 +1,21 @@
+import { useNavigate } from 'react-router-dom';
+import Button from '../common/Button/Button';
+import * as S from './DiscussionList.styled';
+import { ROUTES } from '@/constants/routes';
+
+export default function DiscussionListHeader() {
+  const navigate = useNavigate();
+
+  const handleNavigate = () => {
+    navigate(ROUTES.submitDiscussion);
+  };
+
+  return (
+    <S.HeaderTitleWrapper>
+      <S.HeaderTitle>💬 Discussion</S.HeaderTitle>
+      <Button variant="primary" onClick={handleNavigate}>
+        작성하기
+      </Button>
+    </S.HeaderTitleWrapper>
+  );
+}

--- a/frontend/src/components/DiscussionList/DiscussionListItem.tsx
+++ b/frontend/src/components/DiscussionList/DiscussionListItem.tsx
@@ -10,7 +10,7 @@ export default function DiscussionListItem({
   commentCount,
 }: Omit<Discussion, 'id'>) {
   return (
-    <S.DiscussionItemContainer>
+    <S.ItemContainer>
       <S.ContentWrapper>
         <S.BadgeWrapper>
           {/* TODO: Badge 색상 변경 필요 @프룬 */}
@@ -22,13 +22,13 @@ export default function DiscussionListItem({
         <S.Title>{title}</S.Title>
       </S.ContentWrapper>
 
-      <S.DiscussionRight>
+      <S.ItemRight>
         <S.WriterImg src={member.imageUrl} />
         <S.CommentWrapper>
           <S.CommentCountIcon />
           <p>{commentCount}</p>
         </S.CommentWrapper>
-      </S.DiscussionRight>
-    </S.DiscussionItemContainer>
+      </S.ItemRight>
+    </S.ItemContainer>
   );
 }

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -12,8 +12,6 @@ import * as Sentry from '@sentry/react';
 import { ThemeProvider } from 'styled-components';
 import { theme } from './styles/theme';
 import './styles/fonts.css';
-import DashboardDiscussionPage from './pages/DashboardPage/Discussion';
-import DashboardDiscussionCommentPage from './pages/DashboardPage/DiscussionComment';
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -32,24 +30,40 @@ Sentry.init({
   replaysOnErrorSampleRate: 1.0,
 });
 
-const MissionDetailPage = lazy(() => import('./pages/MissionDetailPage'));
+// 메인
 const MainPage = lazy(() => import('./pages/MainPage'));
-const MissionSubmitPage = lazy(() => import('./pages/MissionSubmitPage'));
+const AboutPage = lazy(() => import('./pages/AboutPage/AboutPage'));
 const UserProfilePage = lazy(() => import('./pages/UserProfilePage'));
 // const GuidePage = lazy(() => import('./pages/GuidePage'));
-const ErrorPage = lazy(() => import('./pages/ErrorPage'));
-const AboutPage = lazy(() => import('./pages/AboutPage/AboutPage'));
+
+// 미션
+const MissionDetailPage = lazy(() => import('./pages/MissionDetailPage'));
+const MissionSubmitPage = lazy(() => import('./pages/MissionSubmitPage'));
+const MissionListPage = lazy(() => import('./pages/MissionListPage'));
+
+// 풀이 (솔루션)
+const SolutionListPage = lazy(() => import('./pages/SolutionListPage'));
+const SolutionDetailPage = lazy(() => import('./pages/SolutionDetailPage'));
+
+// 디스커션
 const DiscussionDetailPage = lazy(() => import('./pages/DiscussionDetailPage'));
 const DiscussionSubmitPage = lazy(() => import('./pages/DiscussionSubmitPage'));
-const SolutionListPage = lazy(() => import('./pages/SolutionListPage'));
-const MissionListPage = lazy(() => import('./pages/MissionListPage'));
-const SolutionDetailPage = lazy(() => import('./pages/SolutionDetailPage'));
+const DiscussionListPage = lazy(() => import('./pages/DiscussionListPage'));
+
+// 대시보드
 const DashboardPage = lazy(() => import('./pages/DashboardPage'));
+const DashboardDiscussionPage = lazy(() => import('./pages/DashboardPage/Discussion'));
+const DashboardDiscussionCommentPage = lazy(
+  () => import('./pages/DashboardPage/DiscussionComment'),
+);
 const DashBoardMissionInProgressPage = lazy(
   () => import('./pages/DashboardPage/MissionInProgress'),
 );
 const MyCommentsPage = lazy(() => import('./pages/DashboardPage/MyComments'));
 const SubmittedSolutionList = lazy(() => import('./components/DashBoard/SubmittedSolutions'));
+
+// 기타
+const ErrorPage = lazy(() => import('./pages/ErrorPage'));
 
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
@@ -222,6 +236,16 @@ const routes = [
       <App>
         <Suspense fallback={<LoadingSpinner />}>
           <DiscussionSubmitPage />
+        </Suspense>
+      </App>
+    ),
+  },
+  {
+    path: ROUTES.discussions,
+    element: (
+      <App>
+        <Suspense fallback={<LoadingSpinner />}>
+          <DiscussionListPage />
         </Suspense>
       </App>
     ),

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -256,46 +256,46 @@ export const router = createBrowserRouter(routes, {
   basename: ROUTES.main,
 });
 
-async function enableMocking() {
-  if (process.env.NODE_ENV !== 'development') {
-    return;
-  }
+// async function enableMocking() {
+//   if (process.env.NODE_ENV !== 'development') {
+//     return;
+//   }
 
-  const { worker } = await import('./mocks/browser');
+//   const { worker } = await import('./mocks/browser');
 
-  // `worker.start()` returns a Promise that resolves
-  // once the Service Worker is up and ready to intercept requests.
-  return worker.start();
-}
+//   // `worker.start()` returns a Promise that resolves
+//   // once the Service Worker is up and ready to intercept requests.
+//   return worker.start();
+// }
 
-enableMocking().then(() => {
-  root.render(
-    <React.StrictMode>
-      <QueryClientProvider client={queryClient}>
-        <QueryErrorBoundary>
-          <ErrorBoundary fallback={<div>에러에요!</div>}>
-            <ThemeProvider theme={theme}>
-              <GlobalStyle />
-              <RouterProvider router={router} />
-            </ThemeProvider>
-          </ErrorBoundary>
-        </QueryErrorBoundary>
-      </QueryClientProvider>
-    </React.StrictMode>,
-  );
-});
+// enableMocking().then(() => {
+//   root.render(
+//     <React.StrictMode>
+//       <QueryClientProvider client={queryClient}>
+//         <QueryErrorBoundary>
+//           <ErrorBoundary fallback={<div>에러에요!</div>}>
+//             <ThemeProvider theme={theme}>
+//               <GlobalStyle />
+//               <RouterProvider router={router} />
+//             </ThemeProvider>
+//           </ErrorBoundary>
+//         </QueryErrorBoundary>
+//       </QueryClientProvider>
+//     </React.StrictMode>,
+//   );
+// });
 
-// root.render(
-//   <React.StrictMode>
-//     <QueryClientProvider client={queryClient}>
-//       <QueryErrorBoundary>
-//         <ErrorBoundary fallback={<div>에러에요!</div>}>
-//           <ThemeProvider theme={theme}>
-//             <GlobalStyle />
-//             <RouterProvider router={router} />
-//           </ThemeProvider>
-//         </ErrorBoundary>
-//       </QueryErrorBoundary>
-//     </QueryClientProvider>
-//   </React.StrictMode>,
-// );
+root.render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <QueryErrorBoundary>
+        <ErrorBoundary fallback={<div>에러에요!</div>}>
+          <ThemeProvider theme={theme}>
+            <GlobalStyle />
+            <RouterProvider router={router} />
+          </ThemeProvider>
+        </ErrorBoundary>
+      </QueryErrorBoundary>
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/frontend/src/pages/DiscussionDetailPage/DiscussionDetailHeader.tsx
+++ b/frontend/src/pages/DiscussionDetailPage/DiscussionDetailHeader.tsx
@@ -1,6 +1,9 @@
+import Button from '@/components/common/Button/Button';
 import * as S from './DiscussionDetailPage.styled';
 import TagButton from '@/components/common/TagButton';
 import type { DiscussionDetail } from '@/types/discussion';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@/constants/routes';
 
 interface DiscussionDetailHeaderProps {
   discussion: DiscussionDetail;
@@ -9,11 +12,22 @@ interface DiscussionDetailHeaderProps {
 export default function DiscussionDetailHeader({ discussion }: DiscussionDetailHeaderProps) {
   const { mission, member, title, hashTags } = discussion;
 
+  const navigate = useNavigate();
+
+  const handleNavigate = () => {
+    navigate(ROUTES.submitDiscussion);
+  };
+
   return (
     <S.DiscussionDetailHeaderContainer>
       <S.ThumbnailWrapper>
         <S.HeaderLeftArea>
-          {mission && <S.MissionTitle># {mission.title}</S.MissionTitle>}
+          <S.MissionActionHeader>
+            {mission && <S.MissionTitle># {mission.title}</S.MissionTitle>}
+            <Button variant="primary" onClick={handleNavigate}>
+              작성하기
+            </Button>
+          </S.MissionActionHeader>
           <S.Title>{title}</S.Title>
           <S.DiscussionDetailInfo>
             <S.HeaderUserInfo>

--- a/frontend/src/pages/DiscussionDetailPage/DiscussionDetailHeader.tsx
+++ b/frontend/src/pages/DiscussionDetailPage/DiscussionDetailHeader.tsx
@@ -14,7 +14,7 @@ export default function DiscussionDetailHeader({ discussion }: DiscussionDetailH
 
   const navigate = useNavigate();
 
-  const handleNavigate = () => {
+  const handleToSubmitDiscussion = () => {
     navigate(ROUTES.submitDiscussion);
   };
 
@@ -24,7 +24,7 @@ export default function DiscussionDetailHeader({ discussion }: DiscussionDetailH
         <S.HeaderLeftArea>
           <S.MissionActionHeader>
             {mission && <S.MissionTitle># {mission.title}</S.MissionTitle>}
-            <Button variant="primary" onClick={handleNavigate}>
+            <Button variant="primary" onClick={handleToSubmitDiscussion}>
               작성하기
             </Button>
           </S.MissionActionHeader>

--- a/frontend/src/pages/DiscussionDetailPage/DiscussionDetailPage.styled.ts
+++ b/frontend/src/pages/DiscussionDetailPage/DiscussionDetailPage.styled.ts
@@ -10,6 +10,7 @@ export const DiscussionDetailTitle = styled.h2`
   margin: 4.5rem 0;
   ${({ theme }) => theme.font.heading1}
   width: fit-content;
+  cursor: pointer;
 `;
 
 export const MissionTitle = styled.div`

--- a/frontend/src/pages/DiscussionDetailPage/DiscussionDetailPage.styled.ts
+++ b/frontend/src/pages/DiscussionDetailPage/DiscussionDetailPage.styled.ts
@@ -53,6 +53,12 @@ export const HeaderLeftArea = styled.div`
   flex-direction: column;
 `;
 
+export const MissionActionHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
 export const DiscussionDetailInfo = styled.div`
   display: flex;
   width: 100%;

--- a/frontend/src/pages/DiscussionDetailPage/index.tsx
+++ b/frontend/src/pages/DiscussionDetailPage/index.tsx
@@ -6,6 +6,8 @@ import CommentSection from '@/components/CommentSection';
 import usePathnameAt from '@/hooks/usePathnameAt';
 import useDiscussion from '@/hooks/useDiscussion';
 import { useDiscussionComments } from '@/hooks/useDiscussionComments';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@/constants/routes';
 
 export default function DiscussionDetailPage() {
   const { data: userInfo } = useUserInfo();
@@ -16,9 +18,17 @@ export default function DiscussionDetailPage() {
 
   const isLoggedIn = Boolean(userInfo);
 
+  const navigate = useNavigate();
+
+  const handleToDiscussionList = () => {
+    navigate(ROUTES.discussions);
+  };
+
   return (
     <S.DiscussionDetailPageContainer>
-      <S.DiscussionDetailTitle>💬 Discussion</S.DiscussionDetailTitle>
+      <S.DiscussionDetailTitle onClick={handleToDiscussionList}>
+        💬 Discussion
+      </S.DiscussionDetailTitle>
       <DiscussionDetailHeader discussion={discussion} />
       <S.DiscussionDescription source={discussion.content} />
       <CommentSection

--- a/frontend/src/pages/DiscussionListPage/DiscussionListPage.styled.ts
+++ b/frontend/src/pages/DiscussionListPage/DiscussionListPage.styled.ts
@@ -8,7 +8,3 @@ export const DiscussionListPageContainer = styled.div`
   width: 100%;
   max-width: 100rem;
 `;
-
-export const DiscussionListTitle = styled.h1`
-  ${(props) => props.theme.font.heading1}
-`;

--- a/frontend/src/pages/DiscussionListPage/index.tsx
+++ b/frontend/src/pages/DiscussionListPage/index.tsx
@@ -1,11 +1,12 @@
-import DiscussionList from '@/components/DiscussionList';
+import DiscussionListContent from '@/components/DiscussionList/DiscussionListContent';
 import * as S from './DiscussionListPage.styled';
+import DiscussionListHeader from '@/components/DiscussionList/DiscussionListHeader';
 
 export default function DiscussionListPage() {
   return (
     <S.DiscussionListPageContainer>
-      <S.DiscussionListTitle>💬 Discussion</S.DiscussionListTitle>
-      <DiscussionList />
+      <DiscussionListHeader />
+      <DiscussionListContent />
     </S.DiscussionListPageContainer>
   );
 }


### PR DESCRIPTION
#### 구현 요약

1. 디스커션 작성하기 버튼을 추가했습니다. (디스커션 리스트, 상세 페이지)
- 디스커션 리스트
![image](https://github.com/user-attachments/assets/ba6789bf-c4d0-427a-983e-df79ee72e98a)
- 디스커션 상세
![image](https://github.com/user-attachments/assets/e2a81e6e-5f89-4c5a-9808-c5b4605fadde)

2. 디스커션 상세 페이지에서 타이틀 클릭 시 디스커션 리스트로 이동하는 기능을 추가했습니다.

https://github.com/user-attachments/assets/b289f15e-456d-49d1-8525-a579b7057014



#### 연관 이슈

- close #497

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
