### PR TITLE
flyway 도입을 위한 설정 (issue #486)

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -42,6 +42,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'io.micrometer:micrometer-registry-prometheus'
 
+    // flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/backend/src/main/java/develup/api/config/FlywayConfig.java
+++ b/backend/src/main/java/develup/api/config/FlywayConfig.java
@@ -1,0 +1,17 @@
+package develup.api.config;
+
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FlywayConfig {
+
+    @Bean
+    public FlywayMigrationStrategy flywayMigrationStrategy() {
+        return flyway -> {
+            flyway.repair();
+            flyway.migrate();
+        };
+    }
+}

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,96 @@
+CREATE TABLE member (
+    created_at TIMESTAMP(6) NOT NULL,
+    id BIGINT AUTO_INCREMENT,
+    social_id BIGINT NOT NULL,
+    email VARCHAR(255),
+    image_url VARCHAR(255) NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    provider VARCHAR(255) NOT NULL CHECK (provider IN ('GITHUB')),
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE mission (
+    id BIGINT AUTO_INCREMENT,
+    summary VARCHAR(255) NOT NULL,
+    thumbnail VARCHAR(255) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    url VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE discussion (
+    created_at TIMESTAMP(6) NOT NULL,
+    id BIGINT AUTO_INCREMENT,
+    member_id BIGINT NOT NULL,
+    mission_id BIGINT,
+    content TEXT NOT NULL,
+    title VARCHAR(255),
+    PRIMARY KEY (id),
+    FOREIGN KEY (member_id) REFERENCES member(id),
+    FOREIGN KEY (mission_id) REFERENCES mission(id)
+);
+
+CREATE TABLE discussion_comment (
+    created_at TIMESTAMP(6) NOT NULL,
+    deleted_at TIMESTAMP(6),
+    discussion_id BIGINT NOT NULL,
+    id BIGINT AUTO_INCREMENT,
+    member_id BIGINT NOT NULL,
+    parent_comment_id BIGINT,
+    content TEXT NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (discussion_id) REFERENCES discussion(id),
+    FOREIGN KEY (member_id) REFERENCES member(id),
+    FOREIGN KEY (parent_comment_id) REFERENCES discussion_comment(id)
+);
+
+CREATE TABLE hash_tag (
+    id BIGINT AUTO_INCREMENT,
+    name VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE discussion_hash_tag (
+    discussion_id BIGINT NOT NULL,
+    hash_tag_id BIGINT NOT NULL,
+    PRIMARY KEY (discussion_id, hash_tag_id),
+    FOREIGN KEY (discussion_id) REFERENCES discussion(id),
+    FOREIGN KEY (hash_tag_id) REFERENCES hash_tag(id)
+);
+
+CREATE TABLE mission_hash_tag (
+    hash_tag_id BIGINT NOT NULL,
+    id BIGINT AUTO_INCREMENT,
+    mission_id BIGINT NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (hash_tag_id) REFERENCES hash_tag(id),
+    FOREIGN KEY (mission_id) REFERENCES mission(id)
+);
+
+CREATE TABLE solution (
+    created_at TIMESTAMP(6) NOT NULL,
+    id BIGINT AUTO_INCREMENT,
+    member_id BIGINT NOT NULL,
+    mission_id BIGINT NOT NULL,
+    description TEXT,
+    status VARCHAR(255) NOT NULL CHECK (status IN ('IN_PROGRESS','COMPLETED')),
+    title VARCHAR(255),
+    url VARCHAR(255),
+    PRIMARY KEY (id),
+    FOREIGN KEY (member_id) REFERENCES member(id),
+    FOREIGN KEY (mission_id) REFERENCES mission(id)
+);
+
+CREATE TABLE solution_comment (
+    created_at TIMESTAMP(6) NOT NULL,
+    deleted_at TIMESTAMP(6),
+    id BIGINT AUTO_INCREMENT,
+    member_id BIGINT NOT NULL,
+    parent_comment_id BIGINT,
+    solution_id BIGINT NOT NULL,
+    content TEXT NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (member_id) REFERENCES member(id),
+    FOREIGN KEY (parent_comment_id) REFERENCES solution_comment(id),
+    FOREIGN KEY (solution_id) REFERENCES solution(id)
+);

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,43 +1,43 @@
 CREATE TABLE member (
-    created_at TIMESTAMP(6) NOT NULL,
     id BIGINT AUTO_INCREMENT,
-    social_id BIGINT NOT NULL,
     email VARCHAR(255),
-    image_url VARCHAR(255) NOT NULL,
-    name VARCHAR(255) NOT NULL,
     provider VARCHAR(255) NOT NULL CHECK (provider IN ('GITHUB')),
+    social_id BIGINT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    image_url VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
     PRIMARY KEY (id)
 );
 
 CREATE TABLE mission (
     id BIGINT AUTO_INCREMENT,
-    summary VARCHAR(255) NOT NULL,
-    thumbnail VARCHAR(255) NOT NULL,
     title VARCHAR(255) NOT NULL,
+    thumbnail VARCHAR(255) NOT NULL,
+    summary VARCHAR(255) NOT NULL,
     url VARCHAR(255) NOT NULL,
     PRIMARY KEY (id)
 );
 
 CREATE TABLE discussion (
-    created_at TIMESTAMP(6) NOT NULL,
     id BIGINT AUTO_INCREMENT,
-    member_id BIGINT NOT NULL,
-    mission_id BIGINT,
-    content TEXT NOT NULL,
     title VARCHAR(255),
+    content TEXT NOT NULL,
+    mission_id BIGINT,
+    member_id BIGINT NOT NULL,
+    created_at TIMESTAMP(6) NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (member_id) REFERENCES member(id),
     FOREIGN KEY (mission_id) REFERENCES mission(id)
 );
 
 CREATE TABLE discussion_comment (
-    created_at TIMESTAMP(6) NOT NULL,
-    deleted_at TIMESTAMP(6),
-    discussion_id BIGINT NOT NULL,
     id BIGINT AUTO_INCREMENT,
+    content TEXT NOT NULL,
+    discussion_id BIGINT NOT NULL,
     member_id BIGINT NOT NULL,
     parent_comment_id BIGINT,
-    content TEXT NOT NULL,
+    deleted_at TIMESTAMP(6),
+    created_at TIMESTAMP(6) NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (discussion_id) REFERENCES discussion(id),
     FOREIGN KEY (member_id) REFERENCES member(id),
@@ -59,36 +59,36 @@ CREATE TABLE discussion_hash_tag (
 );
 
 CREATE TABLE mission_hash_tag (
-    hash_tag_id BIGINT NOT NULL,
     id BIGINT AUTO_INCREMENT,
     mission_id BIGINT NOT NULL,
+    hash_tag_id BIGINT NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (hash_tag_id) REFERENCES hash_tag(id),
     FOREIGN KEY (mission_id) REFERENCES mission(id)
 );
 
 CREATE TABLE solution (
-    created_at TIMESTAMP(6) NOT NULL,
     id BIGINT AUTO_INCREMENT,
-    member_id BIGINT NOT NULL,
     mission_id BIGINT NOT NULL,
-    description TEXT,
-    status VARCHAR(255) NOT NULL CHECK (status IN ('IN_PROGRESS','COMPLETED')),
+    member_id BIGINT NOT NULL,
     title VARCHAR(255),
+    description TEXT,
     url VARCHAR(255),
+    status VARCHAR(255) NOT NULL CHECK (status IN ('IN_PROGRESS','COMPLETED')),
+    created_at TIMESTAMP(6) NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (member_id) REFERENCES member(id),
     FOREIGN KEY (mission_id) REFERENCES mission(id)
 );
 
 CREATE TABLE solution_comment (
-    created_at TIMESTAMP(6) NOT NULL,
-    deleted_at TIMESTAMP(6),
     id BIGINT AUTO_INCREMENT,
+    content TEXT NOT NULL,
+    solution_id BIGINT NOT NULL,
     member_id BIGINT NOT NULL,
     parent_comment_id BIGINT,
-    solution_id BIGINT NOT NULL,
-    content TEXT NOT NULL,
+    deleted_at TIMESTAMP(6),
+    created_at TIMESTAMP(6) NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (member_id) REFERENCES member(id),
     FOREIGN KEY (parent_comment_id) REFERENCES solution_comment(id),

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -6,7 +6,7 @@ CREATE TABLE member (
     name VARCHAR(255) NOT NULL,
     image_url VARCHAR(255) NOT NULL,
     created_at TIMESTAMP(6) NOT NULL,
-    PRIMARY KEY (id)
+    CONSTRAINT pk_member PRIMARY KEY (id)
 );
 
 CREATE TABLE mission (
@@ -15,7 +15,7 @@ CREATE TABLE mission (
     thumbnail VARCHAR(255) NOT NULL,
     summary VARCHAR(255) NOT NULL,
     url VARCHAR(255) NOT NULL,
-    PRIMARY KEY (id)
+    CONSTRAINT pk_mission PRIMARY KEY (id)
 );
 
 CREATE TABLE discussion (
@@ -25,9 +25,9 @@ CREATE TABLE discussion (
     mission_id BIGINT,
     member_id BIGINT NOT NULL,
     created_at TIMESTAMP(6) NOT NULL,
-    PRIMARY KEY (id),
-    FOREIGN KEY (member_id) REFERENCES member(id),
-    FOREIGN KEY (mission_id) REFERENCES mission(id)
+    CONSTRAINT pk_discussion PRIMARY KEY (id),
+    CONSTRAINT fk_member FOREIGN KEY (member_id) REFERENCES member(id),
+    CONSTRAINT fk_mission FOREIGN KEY (mission_id) REFERENCES mission(id)
 );
 
 CREATE TABLE discussion_comment (
@@ -38,33 +38,33 @@ CREATE TABLE discussion_comment (
     parent_comment_id BIGINT,
     deleted_at TIMESTAMP(6),
     created_at TIMESTAMP(6) NOT NULL,
-    PRIMARY KEY (id),
-    FOREIGN KEY (discussion_id) REFERENCES discussion(id),
-    FOREIGN KEY (member_id) REFERENCES member(id),
-    FOREIGN KEY (parent_comment_id) REFERENCES discussion_comment(id)
+    CONSTRAINT pk_discussion_comment PRIMARY KEY (id),
+    CONSTRAINT fk_discussion FOREIGN KEY (discussion_id) REFERENCES discussion(id),
+    CONSTRAINT fk_member FOREIGN KEY (member_id) REFERENCES member(id),
+    CONSTRAINT fk_discussion_comment FOREIGN KEY (parent_comment_id) REFERENCES discussion_comment(id)
 );
 
 CREATE TABLE hash_tag (
     id BIGINT AUTO_INCREMENT,
     name VARCHAR(255) NOT NULL,
-    PRIMARY KEY (id)
+    CONSTRAINT pk_hash_tag PRIMARY KEY (id)
 );
 
 CREATE TABLE discussion_hash_tag (
     discussion_id BIGINT NOT NULL,
     hash_tag_id BIGINT NOT NULL,
-    PRIMARY KEY (discussion_id, hash_tag_id),
-    FOREIGN KEY (discussion_id) REFERENCES discussion(id),
-    FOREIGN KEY (hash_tag_id) REFERENCES hash_tag(id)
+    CONSTRAINT pk_discussion_hash_tag PRIMARY KEY (discussion_id, hash_tag_id),
+    CONSTRAINT fk_discussion FOREIGN KEY (discussion_id) REFERENCES discussion(id),
+    CONSTRAINT fk_hash_tag FOREIGN KEY (hash_tag_id) REFERENCES hash_tag(id)
 );
 
 CREATE TABLE mission_hash_tag (
     id BIGINT AUTO_INCREMENT,
     mission_id BIGINT NOT NULL,
     hash_tag_id BIGINT NOT NULL,
-    PRIMARY KEY (id),
-    FOREIGN KEY (hash_tag_id) REFERENCES hash_tag(id),
-    FOREIGN KEY (mission_id) REFERENCES mission(id)
+    CONSTRAINT pk_mission_hash_tag PRIMARY KEY (id),
+    CONSTRAINT fk_hash_tag FOREIGN KEY (hash_tag_id) REFERENCES hash_tag(id),
+    CONSTRAINT fk_mission FOREIGN KEY (mission_id) REFERENCES mission(id)
 );
 
 CREATE TABLE solution (
@@ -76,9 +76,9 @@ CREATE TABLE solution (
     url VARCHAR(255),
     status VARCHAR(255) NOT NULL CHECK (status IN ('IN_PROGRESS','COMPLETED')),
     created_at TIMESTAMP(6) NOT NULL,
-    PRIMARY KEY (id),
-    FOREIGN KEY (member_id) REFERENCES member(id),
-    FOREIGN KEY (mission_id) REFERENCES mission(id)
+    CONSTRAINT pk_solution PRIMARY KEY (id),
+    CONSTRAINT fk_member FOREIGN KEY (member_id) REFERENCES member(id),
+    CONSTRAINT fk_mission FOREIGN KEY (mission_id) REFERENCES mission(id)
 );
 
 CREATE TABLE solution_comment (
@@ -89,8 +89,8 @@ CREATE TABLE solution_comment (
     parent_comment_id BIGINT,
     deleted_at TIMESTAMP(6),
     created_at TIMESTAMP(6) NOT NULL,
-    PRIMARY KEY (id),
-    FOREIGN KEY (member_id) REFERENCES member(id),
-    FOREIGN KEY (parent_comment_id) REFERENCES solution_comment(id),
-    FOREIGN KEY (solution_id) REFERENCES solution(id)
+    CONSTRAINT pk_solution_comment PRIMARY KEY (id),
+    CONSTRAINT fk_member FOREIGN KEY (member_id) REFERENCES member(id),
+    CONSTRAINT fk_solution_comment FOREIGN KEY (parent_comment_id) REFERENCES solution_comment(id),
+    CONSTRAINT fk_solution FOREIGN KEY (solution_id) REFERENCES solution(id)
 );

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -3,6 +3,8 @@ spring:
     console:
       enabled: true
       path: /h2-console
+  flyway:
+    enabled: false
   datasource:
     url: jdbc:h2:mem:database;
     driver-class-name: org.h2.Driver


### PR DESCRIPTION
#### 구현 요약

flyway 설정을 추가했습니다.
hibernate 의 ddl-auto 옵션은 ~모두 제거했어요.~ validate 로 수정했습니다!

- application-dev.yml 및 application-prod.yml 변경 사항
```
  flyway:
    enabled: true
    baseline-on-migrate: true
    baseline-version: 0
  jpa:
    defer-datasource-initialization: false
```
추가로 application-dev.yml 에 common 파일 jpa 설정과 겹치는 부분이 있어서 제거했는데, prod 는 추후 datasource 작업이 될 때 함께 수정되면 좋을 것 같아요.
- application-local.yml 에 h2 관련 설정이 없어서 추가했습니다.
```
spring:
  h2:
    console:
      enabled: true
      path: /h2-console
  datasource:
    url: jdbc:h2:mem:database;
    driver-class-name: org.h2.Driver
 ```

- `flyway.repair();` 는 스키마 변경 이력과 실제 스키마 간의 불일치를 해결하기 위한 설정입니다.
 마이그레이션이 실패한 경우 flyway_schema_history 테이블에 남는 실패 기록을 제거하고, 실제 마이그레이션 파일들이 손실되거나 이동된 경우 flyway_schema_history의 기록을 정리해 일관성을 유지합니다.

<img width="1424" alt="스크린샷 2024-09-23 오후 8 18 27" src="https://github.com/user-attachments/assets/7a35402c-ac17-4af4-97ac-14517b37ee20">


#### 연관 이슈

- close #486 

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
