### PR TITLE
신규 인프라 및 개발서버에 로깅 및 모니터링 시스템 통합 (issue #481)

### DIFF
--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -70,6 +70,7 @@ jobs:
 
     env:
       BACKEND_APP_IMAGE_NAME: ${{ secrets.DOCKER_REPOSITORY_NAME }}:${{ github.sha }}
+      HOST_NAME: 'A_SERVER'
 
     steps:
       - uses: actions/checkout@v4
@@ -105,6 +106,7 @@ jobs:
 
     env:
       BACKEND_APP_IMAGE_NAME: ${{ needs.find_previous_image_version.outputs.previousImageVersion }}
+      HOST_NAME: 'A_SERVER'
 
     steps:
       - uses: actions/checkout@v4
@@ -141,6 +143,7 @@ jobs:
 
     env:
       BACKEND_APP_IMAGE_NAME: ${{ secrets.DOCKER_REPOSITORY_NAME }}:${{ github.sha }}
+      HOST_NAME: 'B_SERVER'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/backend_dev_cd.yml
+++ b/.github/workflows/backend_dev_cd.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - dev
+      - 'feat/#481'
     paths:
       - backend/**
 

--- a/.github/workflows/backend_dev_cd.yml
+++ b/.github/workflows/backend_dev_cd.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - dev
-      - 'feat/#481'
     paths:
       - backend/**
 

--- a/.github/workflows/backend_dev_cd.yml
+++ b/.github/workflows/backend_dev_cd.yml
@@ -64,6 +64,7 @@ jobs:
       MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
       MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
       MYSQL_ROOT_HOST: ${{ secrets.MYSQL_ROOT_HOST }}
+      HOST_NAME: 'DEV_SERVER'
 
     steps:
       - uses: actions/checkout@v4

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,5 +5,5 @@ COPY ${JAR_FILE} app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-Dspring.profiles.active=${SPRING_PROFILE}", \
+ENTRYPOINT ["java", "-Dspring.profiles.active=${SPRING_PROFILE}", "-DLogging.host=${HOSTNAME}", \
                 "-jar", "/app.jar"]

--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -18,8 +18,8 @@ services:
   promtail-nginx:
     image: grafana/promtail:3.0.0
     volumes:
-      - /home/ubuntu/promtail/nginx-config.yml:/mnt/config/config.yml
-      - /var/log/nginx:/var/log
+      - /home/ubuntu/promtail/nginx-config.yml:/etc/promtail/config.yml
+      - /home/ubuntu/promtail/logs:/logs
     command:
       - config.file=/mnt/config/config.yml
     restart: unless-stopped

--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -9,7 +9,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /home/ubuntu/custom.conf:/etc/nginx/default.conf
+      - /home/ubuntu/custom.conf:/etc/nginx/conf.d/default.conf
       - /etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem:/etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem
       - /etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem:/etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem
       - /var/log/nginx:/var/log/nginx

--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -9,7 +9,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /home/ubuntu/custom.conf:/etc/nginx/nginx.conf
+      - /home/ubuntu/custom.conf:/etc/nginx/default.conf
       - /etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem:/etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem
       - /etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem:/etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem
       - /var/log/nginx:/var/log/nginx

--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -17,11 +17,13 @@ services:
 
   promtail-nginx:
     image: grafana/promtail:3.0.0
+    depends_on:
+      - nginx
     volumes:
       - /home/ubuntu/promtail/nginx-config.yml:/etc/promtail/config.yml
-      - /home/ubuntu/promtail/logs:/logs
+      - /home/ubuntu/promtail/logs:/var/log/nginx
     command:
-      - config.file=/mnt/config/config.yml
+      - '--config.file=/etc/promtail/config.yml'
     restart: unless-stopped
 
   application:

--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -10,6 +10,7 @@ services:
       - "443:443"
     volumes:
       - /home/ubuntu/custom.conf:/etc/nginx/conf.d/default.conf
+      - /home/ubuntu/nginx.conf:/etc/nginx/nginx.conf
       - /etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem:/etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem
       - /etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem:/etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem
       - /var/log/nginx:/var/log/nginx

--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -9,7 +9,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /home/ubuntu/custom.conf:/etc/nginx/conf.d/default.conf
+      - /home/ubuntu/custom.conf:/etc/nginx/nginx.conf
       - /etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem:/etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem
       - /etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem:/etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem
       - /var/log/nginx:/var/log/nginx

--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -21,7 +21,7 @@ services:
       - nginx
     volumes:
       - /home/ubuntu/promtail/nginx-config.yml:/etc/promtail/config.yml
-      - /home/ubuntu/promtail/logs:/var/log/nginx
+      - /var/log/nginx:/var/log/nginx
     command:
       - '--config.file=/etc/promtail/config.yml'
     restart: unless-stopped

--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -33,6 +33,7 @@ services:
       - app-mysql-net
     ports:
       - "8080:8080"
+      - "8082:8082"
     environment:
       TZ: "Asia/Seoul"
       SPRING_PROFILE: dev

--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -12,6 +12,17 @@ services:
       - /home/ubuntu/custom.conf:/etc/nginx/conf.d/default.conf
       - /etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem:/etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem
       - /etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem:/etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem
+      - /var/log/nginx:/var/log/nginx
+    container_name: nginx
+
+  promtail-nginx:
+    image: grafana/promtail:3.0.0
+    volumes:
+      - /home/ubuntu/promtail/nginx-config.yml:/mnt/config/config.yml
+      - /var/log/nginx:/var/log
+    command:
+      - config.file=/mnt/config/config.yml
+    restart: unless-stopped
 
   application:
     image: ${BACKEND_APP_IMAGE_NAME}

--- a/backend/compose.dev.yml
+++ b/backend/compose.dev.yml
@@ -37,6 +37,7 @@ services:
     environment:
       TZ: "Asia/Seoul"
       SPRING_PROFILE: dev
+      HOSTNAME: ${HOST_NAME}
     restart: always
     container_name: develup-app
 

--- a/backend/compose.yml
+++ b/backend/compose.yml
@@ -7,5 +7,6 @@ services:
     environment:
       TZ: "Asia/Seoul"
       SPRING_PROFILE: prod
+      HOSTNAME: ${HOST_NAME}
     restart: always
     container_name: develup-app

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -18,11 +18,11 @@
         <format>
             <label>
                 <pattern>
-                    %d{yyyy-MM-dd HH:mm:ss.SSS} | %t | traceId=%X{traceId} | %highlight(%-5p) | %cyan(%logger{36}) | app=${appName} | host=${HOSTNAME} | %m%n
+                    app=${name},host=${HOSTNAME},level=%level
                 </pattern>
             </label>
             <message>
-                <pattern>${FILE_LOG_PATTERN}</pattern>
+                <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} | %t | traceId=%X{traceId} | %highlight(%-5p) | %cyan(%logger{36}) | %m%n</pattern>
             </message>
             <sortByTime>true</sortByTime>
         </format>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -44,9 +44,6 @@
         <root level="INFO">
             <appender-ref ref="LOKI"/>
         </root>
-        <root level="INFO">
-            <appender-ref ref="Console"/>
-        </root>
     </springProfile>
 
     <springProfile name="prod">

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <springProperty scope="context" name="appName" source="spring.application.name"/>
+    <springProperty scope="context" name="hostName" source="logging.host"/>
 
     <appender name="Console" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -18,7 +19,7 @@
         <format>
             <label>
                 <pattern>
-                    app=${name},host=${HOSTNAME},level=%level
+                    app=${appName},host=${hostName},level=%level
                 </pattern>
             </label>
             <message>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -43,6 +43,9 @@
         <root level="INFO">
             <appender-ref ref="LOKI"/>
         </root>
+        <root level="INFO">
+            <appender-ref ref="Console"/>
+        </root>
     </springProfile>
 
     <springProfile name="prod">

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -47,7 +47,7 @@
 
     <springProfile name="prod">
         <root level="INFO">
-            <appender-ref ref="Console"/>
+            <appender-ref ref="LOKI"/>
         </root>
     </springProfile>
 


### PR DESCRIPTION
#### 구현 요약

1. 개발 서버와 로깅, 모니터링 시스템과 연동
2. 배포 서버와 로깅, 모니터링 시스템 연동

#### 로그 모니터링

개발 서버의 경우 Nginx 로그를 Promtail 을 이용해 수집했고, Spring Boot 는 LogAppender 를 이용해 수집했습니다. 추후 Spring Boot 로그도 Promtail을 이용하도록 변경하는 것이 좋을 것 같습니다. 

하지만, 당장 원활한 모니터링을 위해서는 우선 모니터링 시스템과 프로덕션, 개발 서버의 통합이 먼저라 판단해서 여기까지만 작업했습니다. 

배포 서버의 경우 Spring Boot 만 사용하므로 LogAppender 만으로 로그를 수집했습니다.

#### 매트릭 모니터링

기존과 동일한 방식으로 동작합니다. 다만, 확실한 동작은 신규 배포 서버에 배포가 완료되면 확인할 수 있을 것으로 보입니다.

#### 개발 서버 내 변경 사항
Nginx 설정을 두개의 파일로 분리하도록 변경합니다. 두개의 파일로 변경한 이유는, Nginx 설정 파일의 구조가 계층 형태로 되어있고, 로그 포맷 설정은 최상위 설정에 추가되어야 하기 때문입니다.

custom.conf : 도커 내의 /etc/nginx/conf.d/default.conf 로 매핑 됩니다.
```
server {
    listen 80;
    listen [::]:80;

    server_name dev.api.devel-up.co.kr;
    return 301 https://dev.api.devel-up.co.kr$request_uri;
}
server {
    listen 443 ssl http2;
    server_name dev.api.devel-up.co.kr;

    ssl_certificate /etc/letsencrypt/live/dev.api.devel-up.co.kr/fullchain.pem;
    ssl_certificate_key /etc/letsencrypt/live/dev.api.devel-up.co.kr/privkey.pem;

    location / {
        proxy_pass http://develup-app:8080;
        proxy_set_header X-Request-ID $request_id;
        proxy_set_header Host $http_host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
    }
}
```
nginx.conf : 도커 내의 /etc/nginx/nginx.conf 로 매핑됩니다.
```
user  nginx;
worker_processes  auto;

error_log  /var/log/nginx/error.log notice;
pid        /var/run/nginx.pid;


events {
    worker_connections  1024;
}


http {
    include       /etc/nginx/mime.types;
    default_type  application/octet-stream;

    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
                      '$status $body_bytes_sent "$http_referer" '
                      '"$http_user_agent" "$http_x_forwarded_for" "$request_id"';

    access_log  /var/log/nginx/access.log  main;

    sendfile        on;
    #tcp_nopush     on;

    keepalive_timeout  65;

    #gzip  on;

    include /etc/nginx/conf.d/*.conf;
}
```
#### 모니터링 서버 내 변경 사항
1. compose.yml 변경
내부 command 속성이 인식되지 않아 (') 로 묶었습니다.
2. prometheus.yml 변경
개발 서버, 새로운 배포 서버를 target으로 추가했습니다.
```yaml
global:
  scrape_interval: 3s
  scrape_timeout: 2s
  evaluation_interval: 2s
alerting:
  alertmanagers:
  - static_configs:
    - targets: []
    scheme: http
    timeout: 10s
    api_version: v1
scrape_configs:
- job_name: prometheus
  honor_timestamps: true
  scrape_interval: 3s
  scrape_timeout: 2s
  metrics_path: /actuator/prometheus
  scheme: http
  static_configs:
  - targets:
    - 10.0.0.166:8082
    - 10.0.20.198:8082
    - 10.0.21.172:8082
    - 10.0.0.133:8082
```
2.datasource.yml 변경
내부 구성 요소에 모두 default 설정이 활성화되어있어서 제거했습니다. 있으면 안돌아가요
```yaml
apiVersion: 1

datasources:
- name: Prometheus
  type: prometheus
  url: http://prometheus:9090
  access: proxy
  editable: true

- name: Loki
  type: loki
  access: proxy
  orgId: 1
  url: http://loki:3100
  basicAuth: false
  version: 1
  editable: false
````
#### 연관 이슈

- close #481

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
