### PR TITLE
대시보드 솔루션 및 디스커션 조회 시 createdAt 추가 (issue #531)

### DIFF
--- a/backend/src/main/java/develup/application/discussion/SummarizedDiscussionResponse.java
+++ b/backend/src/main/java/develup/application/discussion/SummarizedDiscussionResponse.java
@@ -1,5 +1,6 @@
 package develup.application.discussion;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import develup.application.hashtag.HashTagResponse;
 import develup.application.member.MemberResponse;
@@ -12,7 +13,8 @@ public record SummarizedDiscussionResponse(
         String mission,
         List<HashTagResponse> hashTags,
         MemberResponse member,
-        int commentCount
+        int commentCount,
+        LocalDateTime createdAt
 ) {
 
     public static SummarizedDiscussionResponse from(Discussion discussion) {
@@ -27,7 +29,8 @@ public record SummarizedDiscussionResponse(
                 discussion.getMissionTitle(),
                 hashTagResponses,
                 MemberResponse.from(discussion.getMember()),
-                100
+                100,
+                discussion.getCreatedAt()
         );
     }
 }

--- a/backend/src/main/java/develup/application/solution/MySolutionResponse.java
+++ b/backend/src/main/java/develup/application/solution/MySolutionResponse.java
@@ -1,10 +1,16 @@
 package develup.application.solution;
 
+import java.time.LocalDateTime;
 import develup.domain.solution.Solution;
 
-public record MySolutionResponse(Long id, String thumbnail, String title) {
+public record MySolutionResponse(Long id, String thumbnail, String title, LocalDateTime createdAt) {
 
     public static MySolutionResponse from(Solution solution) {
-        return new MySolutionResponse(solution.getId(), solution.getMissionThumbnail(), solution.getTitle());
+        return new MySolutionResponse(
+                solution.getId(),
+                solution.getMissionThumbnail(),
+                solution.getTitle(),
+                solution.getCreatedAt()
+        );
     }
 }

--- a/backend/src/test/java/develup/api/DiscussionApiTest.java
+++ b/backend/src/test/java/develup/api/DiscussionApiTest.java
@@ -9,10 +9,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import develup.application.discussion.CreateDiscussionRequest;
 import develup.application.discussion.DiscussionResponse;
 import develup.application.discussion.SummarizedDiscussionResponse;
+import develup.application.hashtag.HashTagResponse;
+import develup.application.member.MemberResponse;
 import develup.domain.discussion.Discussion;
 import develup.domain.hashtag.HashTag;
 import develup.domain.member.Member;
@@ -103,9 +106,23 @@ public class DiscussionApiTest extends ApiTestSupport {
     @Test
     @DisplayName("나의 디스커션 목록을 조회한다.")
     void getMyDiscussions() throws Exception {
+        HashTag hashTag = HashTagTestData.defaultHashTag().withId(1L).build();
+        HashTagResponse hashTagResponse = HashTagResponse.from(hashTag);
+        List<HashTagResponse> hashTags = List.of(hashTagResponse);
+        Member member = MemberTestData.defaultMember().withId(1L).build();
+        MemberResponse memberResponse = MemberResponse.from(member);
+        LocalDateTime now = LocalDateTime.now();
+
         List<SummarizedDiscussionResponse> myDiscussions = List.of(
-                SummarizedDiscussionResponse.from(createDiscussion()),
-                SummarizedDiscussionResponse.from(createDiscussion())
+                new SummarizedDiscussionResponse(
+                        1L,
+                        "루터회관 흡연단속 구현에 대한 고찰",
+                        "루터회관 흡연단속",
+                        hashTags,
+                        memberResponse,
+                        100,
+                        now
+                )
         );
 
         BDDMockito.given(discussionService.getDiscussionsByMemberId(any()))
@@ -121,7 +138,8 @@ public class DiscussionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data[0].hashTags[0].name", equalTo("JAVA")))
                 .andExpect(jsonPath("$.data[0].member.id", equalTo(1)))
                 .andExpect(jsonPath("$.data[0].member.name", equalTo("tester")))
-                .andExpect(jsonPath("$.data[0].commentCount", equalTo(100)));
+                .andExpect(jsonPath("$.data[0].commentCount", equalTo(100)))
+                .andExpect(jsonPath("$.data[0].createdAt").exists());
     }
 
     private Discussion createDiscussion() {

--- a/backend/src/test/java/develup/api/SolutionApiTest.java
+++ b/backend/src/test/java/develup/api/SolutionApiTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import develup.application.solution.MySolutionResponse;
 import develup.application.solution.SolutionResponse;
@@ -189,9 +190,10 @@ class SolutionApiTest extends ApiTestSupport {
     @Test
     @DisplayName("나의 솔루션 목록을 조회한다.")
     void getMySolutions() throws Exception {
+        LocalDateTime now = LocalDateTime.now();
         List<MySolutionResponse> mySolutions = List.of(
-                new MySolutionResponse(1L, "thumbnail", "title"),
-                new MySolutionResponse(2L, "thumbnail", "title")
+                new MySolutionResponse(1L, "thumbnail", "title", now),
+                new MySolutionResponse(2L, "thumbnail", "title", now)
         );
         BDDMockito.given(solutionService.getSubmittedSolutionsByMemberId(any()))
                 .willReturn(mySolutions);
@@ -202,9 +204,11 @@ class SolutionApiTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data[0].id", equalTo(1)))
                 .andExpect(jsonPath("$.data[0].thumbnail", equalTo("thumbnail")))
                 .andExpect(jsonPath("$.data[0].title", equalTo("title")))
+                .andExpect(jsonPath("$.data[0].createdAt").exists())
                 .andExpect(jsonPath("$.data[1].id", equalTo(2)))
                 .andExpect(jsonPath("$.data[1].thumbnail", equalTo("thumbnail")))
-                .andExpect(jsonPath("$.data[1].title", equalTo("title")));
+                .andExpect(jsonPath("$.data[1].title", equalTo("title")))
+                .andExpect(jsonPath("$.data[1].createdAt").exists());
     }
 
     private Solution createSolution() {


### PR DESCRIPTION
#### 구현 요약

대시보드 솔루션 및 디스커션 조회 시 응답에 createdAt을 추가했습니다.

#### 연관 이슈

- close #531 

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
