### PR TITLE
대시보드에서 새로고침시 발생하는 에러를 해결 (issue #539)

### DIFF
--- a/frontend/src/components/DashBoard/DashboardDiscussion/DiscussionItem.tsx
+++ b/frontend/src/components/DashBoard/DashboardDiscussion/DiscussionItem.tsx
@@ -1,6 +1,7 @@
 import * as S from './DashboardDiscussion.styled';
 import type { HashTag } from '@/types';
 import CommentIcon from '@/assets/images/comment-count.svg';
+import { formatDateString } from '@/utils/formatDateString';
 
 interface DiscussionItemProps {
   id: number;
@@ -31,7 +32,7 @@ export default function DiscussionItem({
           })}
         </S.HashTagWrapper>
         <S.CommentText>{title}</S.CommentText>
-        <S.SubText>{createdAt}</S.SubText>
+        <S.SubText>{formatDateString(createdAt)}</S.SubText>
       </S.TextWrapper>
       <S.ImageCommentWrapper>
         <S.ImageWrapper>

--- a/frontend/src/components/DashBoard/SubmittedSolutions/index.tsx
+++ b/frontend/src/components/DashBoard/SubmittedSolutions/index.tsx
@@ -2,6 +2,7 @@ import NoContent from '../DashBoardMissionList/NoContent';
 import Mission from '@/components/Mission';
 import * as S from '@/components/Mission/Mission.styled';
 import useSubmittedSolutions from '@/hooks/useSubmittedSolutions';
+import { formatDateString } from '@/utils/formatDateString';
 
 export default function SubmittedSolutionList() {
   const { data: submittedSolutionList } = useSubmittedSolutions();
@@ -18,7 +19,7 @@ export default function SubmittedSolutionList() {
                 <Mission.Thumbnail thumbnail={mission.thumbnail} />
                 <Mission.InfoWrapper>
                   <Mission.Title>{mission.title}</Mission.Title>
-                  <Mission.Summary>{mission.createdAt}</Mission.Summary>
+                  <Mission.Summary>{formatDateString(mission.createdAt)}</Mission.Summary>
                 </Mission.InfoWrapper>
               </Mission>
             );

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -172,9 +172,7 @@ const routes = [
       <App>
         <QueryErrorBoundary>
           <Suspense fallback={<LoadingSpinner />}>
-            <PrivateRoute redirectTo={ROUTES.login}>
-              <DashboardPage />
-            </PrivateRoute>
+            <DashboardPage />
           </Suspense>
         </QueryErrorBoundary>
       </App>

--- a/frontend/src/pages/DashboardPage/index.tsx
+++ b/frontend/src/pages/DashboardPage/index.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useLocation, Navigate } from 'react-router-dom';
 import DashboardPageLayout from './DashBoardPageLayout';
 import { ROUTES } from '@/constants/routes';
+import PrivateRoute from '@/components/common/PrivateRoute';
 
 export default function DashboardPage() {
   const location = useLocation();
@@ -10,8 +11,10 @@ export default function DashboardPage() {
   }
 
   return (
-    <DashboardPageLayout>
-      <Outlet />
-    </DashboardPageLayout>
+    <PrivateRoute redirectTo={ROUTES.login}>
+      <DashboardPageLayout>
+        <Outlet />
+      </DashboardPageLayout>
+    </PrivateRoute>
   );
 }


### PR DESCRIPTION
#### 구현 요약

로그인 후 대시보드에서 새로고침하면 /login 페이지로 리다이렉트 되는 문제가 있었는데, PrivateRoute를 안쪽에서 감싸줘서 해결하였습니다! 

#### 연관 이슈

- close #539 

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
