### PR TITLE
대시보드에서 새로고침시 로그인 풀리는 문제 해결  (issue #549)

### DIFF
--- a/frontend/src/components/DiscussionList/DiscussionList.styled.ts
+++ b/frontend/src/components/DiscussionList/DiscussionList.styled.ts
@@ -81,3 +81,9 @@ export const HeaderTitleWrapper = styled.div`
 export const HeaderTitle = styled.h1`
   ${(props) => props.theme.font.heading1}
 `;
+
+export const NoContentText = styled.h1`
+  margin-top: 20rem;
+  text-align: center;
+  ${(props) => props.theme.font.heading2}
+`;

--- a/frontend/src/components/DiscussionList/DiscussionListContent.tsx
+++ b/frontend/src/components/DiscussionList/DiscussionListContent.tsx
@@ -10,6 +10,9 @@ interface DiscussionListContentProps {
 export default function DiscussionListContent({ discussions }: DiscussionListContentProps) {
   return (
     <S.ContentContainer>
+      {!discussions.length && (
+        <S.NoContentText>해당 태그에 관련한 디스커션이 존재하지 않아요!</S.NoContentText>
+      )}
       {discussions.map((discussion) => (
         <Link key={discussion.id} to={`/discussions/${discussion.id}`}>
           <DiscussionListItem

--- a/frontend/src/hooks/useUserInfo.ts
+++ b/frontend/src/hooks/useUserInfo.ts
@@ -1,14 +1,13 @@
 import { getUserInfo } from '@/apis/authAPI';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import type { UserInfo } from '../types/user';
 import { userKeys } from './queries/keys';
 
 const useUserInfo = () => {
-  return useQuery<UserInfo>({
+  return useSuspenseQuery<UserInfo>({
     queryKey: userKeys.info,
     queryFn: getUserInfo,
     retry: false,
-    throwOnError: false,
   });
 };
 


### PR DESCRIPTION
#### 구현 요약

회원 정보를 useQuery로 가져왔었는데, useSuspenseQuery로 수정합니다.

#### 연관 이슈

- close #549 

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
