### PR TITLE
전체 디스커션 조회 시 미션, 해시태그 없으면 조회 안되는 문제 수정 (issue #555)

### DIFF
--- a/backend/src/main/java/develup/domain/discussion/Discussion.java
+++ b/backend/src/main/java/develup/domain/discussion/Discussion.java
@@ -79,6 +79,7 @@ public class Discussion extends CreatedAtAuditableEntity {
     }
 
     public String getMissionTitle() {
+        if (mission == null) return "";
         return mission.getTitle();
     }
 

--- a/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
@@ -12,19 +12,20 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
     @Query("""
             SELECT d
             FROM Discussion d
-            JOIN FETCH d.mission m
-            JOIN FETCH d.discussionHashTags.hashTags dhts
-            JOIN FETCH dhts.hashTag ht
+            LEFT JOIN FETCH d.mission m
+            LEFT JOIN FETCH d.discussionHashTags.hashTags dhts
+            LEFT JOIN FETCH dhts.hashTag ht
             WHERE
-                (LOWER(:mission) = 'all' OR m.title = :mission)
+                ((:mission = null) OR LOWER(:mission) = 'all' OR m.title = :mission)
                 AND
-                (LOWER(:hashTag) = 'all' OR EXISTS (
+                ((:hashTag = null) OR LOWER(:hashTag) = 'all' OR EXISTS (
                     SELECT 1
                     FROM DiscussionHashTag dht
                     JOIN dht.hashTag sht
                     WHERE dht.discussion.id = d.id
                     AND sht.name = :hashTag
                 ))
+            ORDER BY d.id DESC
             """)
     List<Discussion> findAllByMissionAndHashTagName(
             @Param("mission") String mission,

--- a/backend/src/main/resources/data.sql
+++ b/backend/src/main/resources/data.sql
@@ -79,6 +79,8 @@ VALUES (1, 1, '1', NULL, NULL, '2024-08-16 13:40:00'),
 INSERT INTO discussion (title, content, mission_id, member_id, created_at)
 VALUES ('객체지향이 뭘까요?', '객체지향에 대해 토론해봅시다.', 1, 1, '2024-09-09 15:30:00'),
        ('디자인패턴 적용한 거 말해봐요', '저는 빌더 패턴 적용해봤어요', 2, 2, '2024-09-09 15:30:00');
+INSERT INTO discussion (title, content, mission_id, member_id, created_at)
+VALUES ('객체지향이 뭘까요?', '객체지향에 대해 토론해봅시다.', null, 1, '2024-09-09 15:30:00');
 
 INSERT INTO discussion_hash_tag (discussion_id, hash_tag_id)
 VALUES (1, 1),

--- a/backend/src/test/java/develup/application/discussion/DiscussionReadServiceTest.java
+++ b/backend/src/test/java/develup/application/discussion/DiscussionReadServiceTest.java
@@ -19,6 +19,7 @@ import develup.support.data.DiscussionTestData;
 import develup.support.data.HashTagTestData;
 import develup.support.data.MemberTestData;
 import develup.support.data.MissionTestData;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
#### 구현 요약

전체 디스커션 조회 시 미션, 해시태그 없으면 조회 안되는 문제 수정

#### 연관 이슈

- close #555

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
