### PR TITLE
디스커션/솔루션 당 부모 댓글 개수 조회하도록 수정 (issue #587)

### DIFF
--- a/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentReadService.java
+++ b/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentReadService.java
@@ -47,10 +47,10 @@ public class DiscussionCommentReadService {
     }
 
     public List<MyDiscussionCommentResponse> getMyComments(Long memberId) {
+        List<MyDiscussionComment> mySolutionComments = discussionCommentRepository.findAllMyDiscussionComment(memberId);
         DiscussionCommentCounts discussionCommentCounts = new DiscussionCommentCounts(
                 discussionRepository.findAllDiscussionCommentCounts()
         );
-        List<MyDiscussionComment> mySolutionComments = discussionCommentRepository.findAllMyDiscussionComment(memberId);
 
         return mySolutionComments.stream()
                 .map(myDiscussionComment -> mapToMyDiscussionCommentResponse(myDiscussionComment, discussionCommentCounts))

--- a/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentReadService.java
+++ b/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentReadService.java
@@ -57,7 +57,7 @@ public class DiscussionCommentReadService {
                 .toList();
     }
 
-    private static MyDiscussionCommentResponse mapToMyDiscussionCommentResponse(
+    private MyDiscussionCommentResponse mapToMyDiscussionCommentResponse(
             MyDiscussionComment myDiscussionComment,
             DiscussionCommentCounts discussionCommentCounts
     ) {

--- a/backend/src/main/java/develup/application/discussion/comment/MyDiscussionCommentResponse.java
+++ b/backend/src/main/java/develup/application/discussion/comment/MyDiscussionCommentResponse.java
@@ -12,14 +12,14 @@ public record MyDiscussionCommentResponse(
         Long discussionCommentCount
 ) {
 
-    public static MyDiscussionCommentResponse from(MyDiscussionComment myDiscussionComment) {
+    public static MyDiscussionCommentResponse of(MyDiscussionComment myDiscussionComment, Long discussionCommentCount) {
         return new MyDiscussionCommentResponse(
                 myDiscussionComment.id(),
                 myDiscussionComment.discussionId(),
                 myDiscussionComment.content(),
                 myDiscussionComment.createdAt(),
                 myDiscussionComment.discussionTitle(),
-                myDiscussionComment.discussionCommentCount()
+                discussionCommentCount
         );
     }
 }

--- a/backend/src/main/java/develup/application/solution/comment/MySolutionCommentResponse.java
+++ b/backend/src/main/java/develup/application/solution/comment/MySolutionCommentResponse.java
@@ -22,4 +22,15 @@ public record MySolutionCommentResponse(
                 mySolutionComment.solutionCommentCount()
         );
     }
+
+    public static MySolutionCommentResponse of(MySolutionComment mySolutionComment, Long solutionCommentCount) {
+        return new MySolutionCommentResponse(
+                mySolutionComment.id(),
+                mySolutionComment.solutionId(),
+                mySolutionComment.content(),
+                mySolutionComment.createdAt(),
+                mySolutionComment.solutionTitle(),
+                solutionCommentCount
+        );
+    }
 }

--- a/backend/src/main/java/develup/application/solution/comment/MySolutionCommentResponse.java
+++ b/backend/src/main/java/develup/application/solution/comment/MySolutionCommentResponse.java
@@ -12,17 +12,6 @@ public record MySolutionCommentResponse(
         Long solutionCommentCount
 ) {
 
-    public static MySolutionCommentResponse from(MySolutionComment mySolutionComment) {
-        return new MySolutionCommentResponse(
-                mySolutionComment.id(),
-                mySolutionComment.solutionId(),
-                mySolutionComment.content(),
-                mySolutionComment.createdAt(),
-                mySolutionComment.solutionTitle(),
-                mySolutionComment.solutionCommentCount()
-        );
-    }
-
     public static MySolutionCommentResponse of(MySolutionComment mySolutionComment, Long solutionCommentCount) {
         return new MySolutionCommentResponse(
                 mySolutionComment.id(),

--- a/backend/src/main/java/develup/application/solution/comment/SolutionCommentReadService.java
+++ b/backend/src/main/java/develup/application/solution/comment/SolutionCommentReadService.java
@@ -57,7 +57,7 @@ public class SolutionCommentReadService {
                 .toList();
     }
 
-    private static MySolutionCommentResponse mapToMySolutionCommentResponse(
+    private MySolutionCommentResponse mapToMySolutionCommentResponse(
             MySolutionComment mySolutionComment,
             SolutionCommentCounts solutionCommentCounts
     ) {

--- a/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
@@ -62,7 +62,7 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
             FROM Discussion d
             JOIN FETCH DiscussionComment dc
             ON dc.discussion.id = d.id
-            WHERE dc.deletedAt IS NULL
+            WHERE dc.deletedAt IS NULL AND dc.parentComment IS NULL
             GROUP BY d.id
             """)
     List<DiscussionCommentCount> findAllDiscussionCommentCounts();

--- a/backend/src/main/java/develup/domain/discussion/comment/DiscussionCommentCounts.java
+++ b/backend/src/main/java/develup/domain/discussion/comment/DiscussionCommentCounts.java
@@ -21,4 +21,8 @@ public class DiscussionCommentCounts {
     public Long getCount(Discussion discussion) {
         return discussionCommentCounts.getOrDefault(discussion.getId(), 0L);
     }
+
+    public Long getCount(Long discussionId) {
+        return discussionCommentCounts.getOrDefault(discussionId, 0L);
+    }
 }

--- a/backend/src/main/java/develup/domain/discussion/comment/DiscussionCommentRepository.java
+++ b/backend/src/main/java/develup/domain/discussion/comment/DiscussionCommentRepository.java
@@ -15,7 +15,7 @@ public interface DiscussionCommentRepository extends JpaRepository<DiscussionCom
             FROM DiscussionComment dc
             JOIN dc.discussion d
             JOIN dc.member m
-            WHERE dc.member.id = :memberId AND dc.deletedAt is null
+            WHERE dc.member.id = :memberId AND dc.deletedAt IS NULL
             """)
     List<MyDiscussionComment> findAllMyDiscussionComment(Long memberId);
 }

--- a/backend/src/main/java/develup/domain/discussion/comment/DiscussionCommentRepository.java
+++ b/backend/src/main/java/develup/domain/discussion/comment/DiscussionCommentRepository.java
@@ -10,13 +10,12 @@ public interface DiscussionCommentRepository extends JpaRepository<DiscussionCom
 
     @Query("""
             SELECT new develup.domain.discussion.comment.MyDiscussionComment(
-                dc.id, dc.discussion.id, dc.content, dc.createdAt, d.title.value, COUNT(dc)
+                dc.id, dc.discussion.id, dc.content, dc.createdAt, d.title.value
             )
             FROM DiscussionComment dc
             JOIN dc.discussion d
             JOIN dc.member m
             WHERE dc.member.id = :memberId AND dc.deletedAt is null
-            GROUP BY dc.id
             """)
     List<MyDiscussionComment> findAllMyDiscussionComment(Long memberId);
 }

--- a/backend/src/main/java/develup/domain/discussion/comment/MyDiscussionComment.java
+++ b/backend/src/main/java/develup/domain/discussion/comment/MyDiscussionComment.java
@@ -7,7 +7,6 @@ public record MyDiscussionComment(
         Long discussionId,
         String content,
         LocalDateTime createdAt,
-        String discussionTitle,
-        Long discussionCommentCount
+        String discussionTitle
 ) {
 }

--- a/backend/src/main/java/develup/domain/solution/SolutionRepository.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionRepository.java
@@ -70,7 +70,7 @@ public interface SolutionRepository extends JpaRepository<Solution, Long> {
             FROM Solution s
             JOIN FETCH SolutionComment sc
             ON sc.solution.id = s.id
-            WHERE sc.deletedAt IS NULL
+            WHERE sc.deletedAt IS NULL AND sc.parentComment IS NULL
             GROUP BY s.id
             """)
     List<SolutionCommentCount> findAllSolutionCommentCounts();

--- a/backend/src/main/java/develup/domain/solution/SolutionRepository.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionRepository.java
@@ -2,6 +2,7 @@ package develup.domain.solution;
 
 import java.util.List;
 import java.util.Optional;
+import develup.domain.solution.comment.SolutionCommentCount;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -61,4 +62,16 @@ public interface SolutionRepository extends JpaRepository<Solution, Long> {
             """)
     @Modifying(clearAutomatically = true)
     void deleteAllComments(Long solutionId);
+
+    @Query("""
+            SELECT new develup.domain.solution.comment.SolutionCommentCount(
+                s.id, count(sc)
+            )
+            FROM Solution s
+            JOIN FETCH SolutionComment sc
+            ON sc.solution.id = s.id
+            WHERE sc.deletedAt IS NULL
+            GROUP BY s.id
+            """)
+    List<SolutionCommentCount> findAllSolutionCommentCounts();
 }

--- a/backend/src/main/java/develup/domain/solution/SolutionRepository.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionRepository.java
@@ -68,7 +68,7 @@ public interface SolutionRepository extends JpaRepository<Solution, Long> {
                 s.id, count(sc)
             )
             FROM Solution s
-            JOIN FETCH SolutionComment sc
+            JOIN SolutionComment sc
             ON sc.solution.id = s.id
             WHERE sc.deletedAt IS NULL AND sc.parentComment IS NULL
             GROUP BY s.id

--- a/backend/src/main/java/develup/domain/solution/comment/MySolutionComment.java
+++ b/backend/src/main/java/develup/domain/solution/comment/MySolutionComment.java
@@ -7,7 +7,6 @@ public record MySolutionComment(
         Long solutionId,
         String content,
         LocalDateTime createdAt,
-        String solutionTitle,
-        Long solutionCommentCount
+        String solutionTitle
 ) {
 }

--- a/backend/src/main/java/develup/domain/solution/comment/SolutionCommentCount.java
+++ b/backend/src/main/java/develup/domain/solution/comment/SolutionCommentCount.java
@@ -1,0 +1,4 @@
+package develup.domain.solution.comment;
+
+public record SolutionCommentCount(Long id, Long count) {
+}

--- a/backend/src/main/java/develup/domain/solution/comment/SolutionCommentCounts.java
+++ b/backend/src/main/java/develup/domain/solution/comment/SolutionCommentCounts.java
@@ -3,7 +3,6 @@ package develup.domain.solution.comment;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import develup.domain.solution.Solution;
 
 public class SolutionCommentCounts {
 
@@ -16,10 +15,6 @@ public class SolutionCommentCounts {
     private Map<Long, Long> toMap(List<SolutionCommentCount> solutionCommentCounts) {
         return solutionCommentCounts.stream()
                 .collect(Collectors.toMap(SolutionCommentCount::id, SolutionCommentCount::count));
-    }
-
-    public Long getCount(Solution solution) {
-        return solutionCommentCounts.getOrDefault(solution.getId(), 0L);
     }
 
     public Long getCount(Long solutionId) {

--- a/backend/src/main/java/develup/domain/solution/comment/SolutionCommentCounts.java
+++ b/backend/src/main/java/develup/domain/solution/comment/SolutionCommentCounts.java
@@ -1,0 +1,28 @@
+package develup.domain.solution.comment;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import develup.domain.solution.Solution;
+
+public class SolutionCommentCounts {
+
+    private final Map<Long, Long> solutionCommentCounts;
+
+    public SolutionCommentCounts(List<SolutionCommentCount> solutionCommentCounts) {
+        this.solutionCommentCounts = toMap(solutionCommentCounts);
+    }
+
+    private Map<Long, Long> toMap(List<SolutionCommentCount> solutionCommentCounts) {
+        return solutionCommentCounts.stream()
+                .collect(Collectors.toMap(SolutionCommentCount::id, SolutionCommentCount::count));
+    }
+
+    public Long getCount(Solution solution) {
+        return solutionCommentCounts.getOrDefault(solution.getId(), 0L);
+    }
+
+    public Long getCount(Long solutionId) {
+        return solutionCommentCounts.getOrDefault(solutionId, 0L);
+    }
+}

--- a/backend/src/main/java/develup/domain/solution/comment/SolutionCommentRepository.java
+++ b/backend/src/main/java/develup/domain/solution/comment/SolutionCommentRepository.java
@@ -10,13 +10,12 @@ public interface SolutionCommentRepository extends JpaRepository<SolutionComment
 
     @Query("""
             SELECT new develup.domain.solution.comment.MySolutionComment(
-                sc.id, sc.solution.id, sc.content, sc.createdAt, s.title.value, COUNT(sc)
+                sc.id, sc.solution.id, sc.content, sc.createdAt, s.title.value
             )
             FROM SolutionComment sc
             JOIN sc.solution s
             JOIN sc.member m
             WHERE sc.member.id = :memberId AND sc.deletedAt IS NULL
-            GROUP BY sc.id
             """)
     List<MySolutionComment> findAllMySolutionComment(Long memberId);
 }

--- a/backend/src/test/java/develup/application/discussion/comment/DiscussionCommentReadServiceTest.java
+++ b/backend/src/test/java/develup/application/discussion/comment/DiscussionCommentReadServiceTest.java
@@ -2,8 +2,10 @@ package develup.application.discussion.comment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import develup.api.exception.DevelupException;
 import develup.domain.discussion.Discussion;
 import develup.domain.discussion.DiscussionRepository;
@@ -97,5 +99,40 @@ class DiscussionCommentReadServiceTest extends IntegrationTestSupport {
         discussionCommentRepository.save(discussionComment);
 
         return discussionComment;
+    }
+
+    @Test
+    @DisplayName("사용자가 작성한 댓글을 조회한다.")
+    void getMyComments() {
+        Discussion discussion = createRootDiscussion();
+        for (int i = 0; i < 10; i++) {
+            createDiscussionComment(discussion);
+        }
+        Member otherMember = memberRepository.save(MemberTestData.defaultMember().build());
+        createDiscussionComment(discussion, otherMember);
+
+        Long memberId = discussion.getMember().getId();
+        List<MyDiscussionCommentResponse> myComments = discussionCommentReadService.getMyComments(memberId);
+
+        assertAll(
+                () -> assertThat(myComments).hasSize(10),
+                () -> assertThat(myComments.getFirst().discussionCommentCount()).isEqualTo(11)
+        );
+    }
+
+    private DiscussionComment createDiscussionComment(Discussion discussion) {
+        DiscussionComment discussionComment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withDiscussion(discussion)
+                .withMember(discussion.getMember())
+                .build();
+        return discussionCommentRepository.save(discussionComment);
+    }
+
+    private DiscussionComment createDiscussionComment(Discussion discussion, Member writer) {
+        DiscussionComment discussionComment = DiscussionCommentTestData.defaultDiscussionComment()
+                .withDiscussion(discussion)
+                .withMember(writer)
+                .build();
+        return discussionCommentRepository.save(discussionComment);
     }
 }

--- a/backend/src/test/java/develup/application/solution/comment/SolutionCommentReadServiceTest.java
+++ b/backend/src/test/java/develup/application/solution/comment/SolutionCommentReadServiceTest.java
@@ -2,8 +2,10 @@ package develup.application.solution.comment;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import develup.api.exception.DevelupException;
 import develup.domain.member.Member;
 import develup.domain.member.MemberRepository;
@@ -97,5 +99,40 @@ class SolutionCommentReadServiceTest extends IntegrationTestSupport {
         solutionCommentRepository.save(solutionComment);
 
         return solutionComment;
+    }
+
+    @Test
+    @DisplayName("사용자가 작성한 댓글을 조회한다.")
+    void getMyComments() {
+        Solution solution = createSolution();
+        for (int i = 0; i < 10; i++) {
+            createSolutionComment(solution);
+        }
+        Member otherMember = memberRepository.save(MemberTestData.defaultMember().build());
+        createSolutionComment(solution, otherMember);
+
+        Long memberId = solution.getMember().getId();
+        List<MySolutionCommentResponse> myComments = solutionCommentReadService.getMyComments(memberId);
+
+        assertAll(
+                () -> assertThat(myComments).hasSize(10),
+                () -> assertThat(myComments.getFirst().solutionCommentCount()).isEqualTo(11)
+        );
+    }
+
+    private SolutionComment createSolutionComment(Solution solution) {
+        SolutionComment solutionComment = SolutionCommentTestData.defaultSolutionComment()
+                .withSolution(solution)
+                .withMember(solution.getMember())
+                .build();
+        return solutionCommentRepository.save(solutionComment);
+    }
+
+    private SolutionComment createSolutionComment(Solution solution, Member writer) {
+        SolutionComment solutionComment = SolutionCommentTestData.defaultSolutionComment()
+                .withSolution(solution)
+                .withMember(writer)
+                .build();
+        return solutionCommentRepository.save(solutionComment);
     }
 }

--- a/backend/src/test/java/develup/application/solution/comment/SolutionCommentReadServiceTest.java
+++ b/backend/src/test/java/develup/application/solution/comment/SolutionCommentReadServiceTest.java
@@ -135,4 +135,33 @@ class SolutionCommentReadServiceTest extends IntegrationTestSupport {
                 .build();
         return solutionCommentRepository.save(solutionComment);
     }
+
+    @Test
+    @DisplayName("사용자가 작성한 댓글을 조회시 솔루션에 달린 댓글 수는 부모 댓글만 반영한다.")
+    void getMyCommentsWhenContainReplyComments() {
+        Solution solution = createSolution();
+        Member otherMember = memberRepository.save(MemberTestData.defaultMember().build());
+        SolutionComment parentComment = createSolutionComment(solution, otherMember);
+
+        for (int i = 0; i < 10; i++) {
+            createSolutionReplyComment(solution, parentComment);
+        }
+
+        Long memberId = solution.getMember().getId();
+        List<MySolutionCommentResponse> myComments = solutionCommentReadService.getMyComments(memberId);
+
+        assertAll(
+                () -> assertThat(myComments).hasSize(10),
+                () -> assertThat(myComments.getFirst().solutionCommentCount()).isEqualTo(1)
+        );
+    }
+
+    private SolutionComment createSolutionReplyComment(Solution solution, SolutionComment parentComment) {
+        SolutionComment solutionComment = SolutionCommentTestData.defaultSolutionComment()
+                .withParentComment(parentComment)
+                .withSolution(solution)
+                .withMember(solution.getMember())
+                .build();
+        return solutionCommentRepository.save(solutionComment);
+    }
 }

--- a/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryTest.java
@@ -178,7 +178,9 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         saveDiscussionComment(savedDiscussion, member);
         saveDeletedDiscussionComment(savedDiscussion, member);
 
-        DiscussionCommentCounts discussionCommentCounts = new DiscussionCommentCounts(discussionRepository.findAllDiscussionCommentCounts());
+        DiscussionCommentCounts discussionCommentCounts = new DiscussionCommentCounts(
+                discussionRepository.findAllDiscussionCommentCounts()
+        );
         Long count = discussionCommentCounts.getCount(savedDiscussion);
 
         assertThat(count).isEqualTo(1);


### PR DESCRIPTION
#### 구현 요약

사용자가 솔루션, 디스커션에 작성한 댓글 조회 시 댓글 개수 잘못 조회하는 오류 수정

댓글 개수는 부모 댓글 개수를 보여줍니다.

#### 연관 이슈

- close #587

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
