### PR TITLE
미션 없을 때, 해시태그 없을 때 디스커션 조회 버그 수정 및 테스트 코드 추가 (issue #588)

### DIFF
--- a/backend/src/main/java/develup/application/discussion/DiscussionReadService.java
+++ b/backend/src/main/java/develup/application/discussion/DiscussionReadService.java
@@ -54,7 +54,7 @@ public class DiscussionReadService {
     }
 
     public Discussion getDiscussion(Long id) {
-        return discussionRepository.findById(id)
+        return discussionRepository.findFetchById(id)
                 .orElseThrow(() -> new DevelupException(ExceptionType.DISCUSSION_NOT_FOUND));
     }
 

--- a/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
@@ -35,11 +35,11 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
     @Query("""
             SELECT d
             FROM Discussion d
-            JOIN FETCH d.mission m
-            JOIN FETCH m.missionHashTags.hashTags mhts
-            JOIN FETCH d.member me
-            JOIN FETCH d.discussionHashTags.hashTags dhts
-            JOIN FETCH dhts.hashTag ht
+            LEFT JOIN FETCH d.mission m
+            LEFT JOIN FETCH m.missionHashTags.hashTags mhts
+            LEFT JOIN FETCH d.member me
+            LEFT JOIN FETCH d.discussionHashTags.hashTags dhts
+            LEFT JOIN FETCH dhts.hashTag ht
             WHERE d.id = :id
             """)
     Optional<Discussion> findFetchById(Long id);

--- a/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
@@ -47,10 +47,10 @@ public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
     @Query("""
             SELECT d
             FROM Discussion d
-            JOIN FETCH d.mission m
-            JOIN FETCH d.member me
-            JOIN FETCH d.discussionHashTags.hashTags dhts
-            JOIN FETCH dhts.hashTag ht
+            LEFT JOIN FETCH d.mission m
+            LEFT JOIN FETCH d.member me
+            LEFT JOIN FETCH d.discussionHashTags.hashTags dhts
+            LEFT JOIN FETCH dhts.hashTag ht
             WHERE me.id = :memberId
             """)
     List<Discussion> findAllByMemberId(Long memberId);

--- a/backend/src/test/java/develup/application/discussion/DiscussionReadServiceTest.java
+++ b/backend/src/test/java/develup/application/discussion/DiscussionReadServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.Collections;
 import java.util.List;
 import develup.api.exception.DevelupException;
 import develup.domain.discussion.Discussion;
@@ -81,8 +82,99 @@ class DiscussionReadServiceTest extends IntegrationTestSupport {
     }
 
     @Test
-    @DisplayName("존재하지 않는 디스커션은 불러올 수 없다.")
+    @DisplayName("디스커션 아이디로 디스커션을 찾는다.")
+    @Transactional
     void getById() {
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMember(member)
+                .withMission(mission)
+                .withHashTags(List.of(hashTag))
+                .build();
+        Long discussionId = discussionRepository.save(discussion).getId();
+
+        DiscussionResponse discussionResponse = discussionReadService.getById(discussionId);
+
+        assertAll(
+                () -> assertThat(discussionResponse.id()).isEqualTo(discussionId),
+                () -> assertThat(discussionResponse.member().id()).isEqualTo(member.getId()),
+                () -> assertThat(discussionResponse.mission().id()).isEqualTo(mission.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("디스커션에 미션이 없을 때 디스커션 아이디로 디스커션을 찾는다.")
+    @Transactional
+    void getByIdWithoutMission() {
+        Member member = memberRepository.save(MemberTestData.defaultMember().withId(1L).build());
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMember(member)
+                .withMission(null)
+                .withHashTags(List.of(hashTag))
+                .build();
+        Long discussionId = discussionRepository.save(discussion).getId();
+
+        DiscussionResponse discussionResponse = discussionReadService.getById(discussionId);
+
+        assertAll(
+                () -> assertThat(discussionResponse.id()).isEqualTo(discussionId),
+                () -> assertThat(discussionResponse.member().id()).isEqualTo(member.getId()),
+                () -> assertThat(discussionResponse.mission()).isNull(),
+                () -> assertThat(discussionResponse.hashTags()).hasSize(1)
+        );
+    }
+
+    @Test
+    @DisplayName("디스커션에 해시태그가 없을 때 디스커션 아이디로 디스커션을 찾는다.")
+    @Transactional
+    void getByIdWithoutHashTags() {
+        Member member = memberRepository.save(MemberTestData.defaultMember().withId(1L).build());
+        Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMember(member)
+                .withMission(mission)
+                .withHashTags(Collections.emptyList())
+                .build();
+        Long discussionId = discussionRepository.save(discussion).getId();
+
+        DiscussionResponse discussionResponse = discussionReadService.getById(discussionId);
+
+        assertAll(
+                () -> assertThat(discussionResponse.id()).isEqualTo(discussionId),
+                () -> assertThat(discussionResponse.member().id()).isEqualTo(member.getId()),
+                () -> assertThat(discussionResponse.mission().id()).isEqualTo(mission.getId()),
+                () -> assertThat(discussionResponse.hashTags()).isEmpty()
+        );
+    }
+
+    @Test
+    @DisplayName("디스커션에 미션과 해시태그가 없을 때 디스커션 아이디로 디스커션을 찾는다.")
+    @Transactional
+    void getByIdWithoutMissionAndHashTags() {
+        Member member = memberRepository.save(MemberTestData.defaultMember().withId(1L).build());
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMember(member)
+                .withMission(null)
+                .withHashTags(Collections.emptyList())
+                .build();
+        Long discussionId = discussionRepository.save(discussion).getId();
+
+        DiscussionResponse discussionResponse = discussionReadService.getById(discussionId);
+
+        assertAll(
+                () -> assertThat(discussionResponse.id()).isEqualTo(discussionId),
+                () -> assertThat(discussionResponse.member().id()).isEqualTo(member.getId()),
+                () -> assertThat(discussionResponse.mission()).isNull(),
+                () -> assertThat(discussionResponse.hashTags()).isEmpty()
+        );
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 디스커션은 불러올 수 없다.")
+    void getByIdWithUnKnownDiscussionId() {
         Long unknownId = -1L;
 
         assertThatThrownBy(() -> discussionReadService.getById(unknownId))

--- a/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryTest.java
@@ -50,15 +50,18 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
         HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
 
-        createDiscussion(mission, hashTag);
-        createDiscussion(mission, hashTag);
+        createDiscussion(mission, List.of(hashTag));
+        createDiscussion(mission, List.of(hashTag));
+        createDiscussion(null, List.of(hashTag));
+        createDiscussion(mission, Collections.emptyList());
+        createDiscussion(null, Collections.emptyList());
 
         List<Discussion> actual = discussionRepository.findAllByMissionAndHashTagName(
                 "all",
                 "all"
         );
 
-        assertThat(actual).hasSize(2);
+        assertThat(actual).hasSize(5);
     }
 
     @Test
@@ -68,8 +71,8 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
         HashTag hashTag1 = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("JAVA").build());
         HashTag hashTag2 = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("객체지향").build());
-        createDiscussion(mission, hashTag1);
-        createDiscussion(mission, hashTag2);
+        createDiscussion(mission, List.of(hashTag1));
+        createDiscussion(mission, List.of(hashTag2));
 
         List<Discussion> discussions = discussionRepository.findAllByMissionAndHashTagName(
                 "all",
@@ -90,8 +93,8 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         Mission mission1 = missionRepository.save(MissionTestData.defaultMission().withTitle("루터회관 흡연단속").build());
         Mission mission2 = missionRepository.save(MissionTestData.defaultMission().withTitle("주문").build());
         HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("JAVA").build());
-        createDiscussion(mission1, hashTag);
-        createDiscussion(mission2, hashTag);
+        createDiscussion(mission1, List.of(hashTag));
+        createDiscussion(mission2, List.of(hashTag));
 
         List<Discussion> discussions = discussionRepository.findAllByMissionAndHashTagName(
                 "루터회관 흡연단속",
@@ -244,13 +247,13 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         assertThat(count).isEqualTo(1);
     }
 
-    private void createDiscussion(Mission mission, HashTag hashTag) {
+    private void createDiscussion(Mission mission, List<HashTag> hashTags) {
         Member member = memberRepository.save(MemberTestData.defaultMember().build());
 
         Discussion discussion = DiscussionTestData.defaultDiscussion()
                 .withMission(mission)
                 .withMember(member)
-                .withHashTags(List.of(hashTag))
+                .withHashTags(hashTags)
                 .build();
 
         discussionRepository.save(discussion);

--- a/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryTest.java
@@ -184,10 +184,25 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
         HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
 
-        Discussion discussionByMember1 = DiscussionTestData.defaultDiscussion()
+        Discussion discussionByMember1_1 = DiscussionTestData.defaultDiscussion()
                 .withMission(mission)
                 .withMember(member1)
                 .withHashTags(List.of(hashTag))
+                .build();
+        Discussion discussionByMember1_2 = DiscussionTestData.defaultDiscussion()
+                .withMission(null)
+                .withMember(member1)
+                .withHashTags(List.of(hashTag))
+                .build();
+        Discussion discussionByMember1_3 = DiscussionTestData.defaultDiscussion()
+                .withMission(mission)
+                .withMember(member1)
+                .withHashTags(Collections.emptyList())
+                .build();
+        Discussion discussionByMember1_4 = DiscussionTestData.defaultDiscussion()
+                .withMission(null)
+                .withMember(member1)
+                .withHashTags(Collections.emptyList())
                 .build();
         Discussion discussionByMember2 = DiscussionTestData.defaultDiscussion()
                 .withMission(mission)
@@ -195,28 +210,19 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
                 .withHashTags(List.of(hashTag))
                 .build();
 
-        discussionRepository.save(discussionByMember1);
+        discussionRepository.save(discussionByMember1_1);
+        discussionRepository.save(discussionByMember1_2);
+        discussionRepository.save(discussionByMember1_3);
+        discussionRepository.save(discussionByMember1_4);
         discussionRepository.save(discussionByMember2);
 
         List<Discussion> discussionsByMember1 = discussionRepository.findAllByMemberId(member1.getId());
         List<Discussion> discussionsByMember2 = discussionRepository.findAllByMemberId(member2.getId());
 
         assertAll(
-                () -> assertThat(discussionsByMember1).hasSize(1),
+                () -> assertThat(discussionsByMember1).hasSize(4),
                 () -> assertThat(discussionsByMember2).hasSize(1)
         );
-    }
-
-    private void createDiscussion(Mission mission, HashTag hashTag) {
-        Member member = memberRepository.save(MemberTestData.defaultMember().build());
-
-        Discussion discussion = DiscussionTestData.defaultDiscussion()
-                .withMission(mission)
-                .withMember(member)
-                .withHashTags(List.of(hashTag))
-                .build();
-
-        discussionRepository.save(discussion);
     }
 
     @Test
@@ -236,6 +242,18 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         Long count = discussionCommentCounts.getCount(savedDiscussion);
 
         assertThat(count).isEqualTo(1);
+    }
+
+    private void createDiscussion(Mission mission, HashTag hashTag) {
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMission(mission)
+                .withMember(member)
+                .withHashTags(List.of(hashTag))
+                .build();
+
+        discussionRepository.save(discussion);
     }
 
     private Discussion getSavedDiscussion(Mission mission, Member member, HashTag hashTag) {

--- a/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryTest.java
@@ -3,6 +3,7 @@ package develup.domain.discussion;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import develup.domain.discussion.comment.DiscussionComment;
@@ -113,6 +114,59 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
                 .withMission(mission)
                 .withMember(member)
                 .withHashTags(List.of(hashTag))
+                .build();
+        Discussion savedDiscussion = discussionRepository.save(discussion);
+
+        assertThat(discussionRepository.findFetchById(savedDiscussion.getId()))
+                .map(Discussion::getId)
+                .hasValue(savedDiscussion.getId());
+    }
+
+    @Test
+    @DisplayName("미션이 없는 디스커션을 식별자로 조회한다.")
+    @Transactional
+    void findFetchByIdWithoutMission() {
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMission(null)
+                .withMember(member)
+                .withHashTags(List.of(hashTag))
+                .build();
+        Discussion savedDiscussion = discussionRepository.save(discussion);
+
+        assertThat(discussionRepository.findFetchById(savedDiscussion.getId()))
+                .map(Discussion::getId)
+                .hasValue(savedDiscussion.getId());
+    }
+
+    @Test
+    @DisplayName("해시태그가 없는 디스커션을 식별자로 조회한다.")
+    @Transactional
+    void findFetchByIdWithoutHashTag() {
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMission(mission)
+                .withMember(member)
+                .withHashTags(Collections.emptyList())
+                .build();
+        Discussion savedDiscussion = discussionRepository.save(discussion);
+
+        assertThat(discussionRepository.findFetchById(savedDiscussion.getId()))
+                .map(Discussion::getId)
+                .hasValue(savedDiscussion.getId());
+    }
+
+    @Test
+    @DisplayName("미션과 해시태그가 없는 디스커션을 식별자로 조회한다.")
+    @Transactional
+    void findFetchByIdWithoutMissionAndHashTag() {
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        Discussion discussion = DiscussionTestData.defaultDiscussion()
+                .withMission(null)
+                .withMember(member)
+                .withHashTags(Collections.emptyList())
                 .build();
         Discussion savedDiscussion = discussionRepository.save(discussion);
 


### PR DESCRIPTION
#### 구현 요약

단 건 조회는 서비스, 레파지토리 테스트 둘 다 추가했는데 다른 것까지 경우의 수를 다 추가하면 서비스 테스트 코드가 너무 헤비해질 여지가 있고 레파지토리 테스트로도 충분히 테스트가 가능해서 나머지는 레파지토리 테스트만 추가했습니다.

- [x] LEFT JOIN 걸기
- [x] 미션 없을 때, 해시태그 없을 때 테스트 코드 추가

### 단 건 조회
```bash
    select
        d1_0.id,
        d1_0.content,
        d1_0.created_at,
        d1_0.member_id,
        d1_0.mission_id,
        d1_0.title 
    from
        discussion d1_0 
    where
        d1_0.id=?
[Hibernate] 
    insert 
    into
        discussion
        (content, created_at, member_id, mission_id, title, id) 
    values
        (?, ?, ?, ?, ?, default)
[Hibernate] 
    select
        d1_0.id,
        d1_0.content,
        d1_0.created_at,
        d1_0.member_id,
        d1_0.mission_id,
        d1_0.title 
    from
        discussion d1_0 
    where
        d1_0.id=?
[Hibernate] 
    select
        ht1_0.discussion_id,
        ht1_0.hash_tag_id 
    from
        discussion_hash_tag ht1_0 
    where
        ht1_0.discussion_id=? 
    order by
        ht1_0.discussion_id,
        ht1_0.hash_tag_id
[Hibernate] 
    select
        m1_0.id,
        m1_0.created_at,
        m1_0.email,
        m1_0.image_url,
        m1_0.name,
        m1_0.provider,
        m1_0.social_id 
    from
        member m1_0 
    where
        m1_0.id=?
[Hibernate] 
    select
        m1_0.id,
        m1_0.url,
        m1_0.summary,
        m1_0.thumbnail,
        m1_0.title 
    from
        mission m1_0 
    where
        m1_0.id=?
[Hibernate] 
    select
        ht1_0.mission_id,
        ht1_0.id,
        ht1_0.hash_tag_id 
    from
        mission_hash_tag ht1_0 
    where
        ht1_0.mission_id=? 
    order by
        ht1_0.id
```
- N + 1 문제가 발생
- fetch join
```java
@Query("""  
        SELECT d        
        FROM Discussion d  
        JOIN FETCH d.mission m  
        JOIN FETCH m.missionHashTags.hashTags mhts  
        JOIN FETCH d.member me  
        JOIN FETCH d.discussionHashTags.hashTags dhts  
        JOIN FETCH dhts.hashTag ht  
        WHERE d.id = :id  
        """)
        Optional<Discussion> findFetchById(Long id);
```

```bash
    select
        d1_0.id,
        d1_0.content,
        d1_0.created_at,
        ht2_0.discussion_id,
        ht2_0.hash_tag_id,
        ht3_0.id,
        ht3_0.name,
        d1_0.member_id,
        m2_0.id,
        m2_0.created_at,
        m2_0.email,
        m2_0.image_url,
        m2_0.name,
        m2_0.provider,
        m2_0.social_id,
        m1_0.id,
        ht1_0.mission_id,
        ht1_0.id,
        ht1_0.hash_tag_id,
        m1_0.url,
        m1_0.summary,
        m1_0.thumbnail,
        m1_0.title,
        d1_0.title 
    from
        discussion d1_0 
    join
        mission m1_0 
            on m1_0.id=d1_0.mission_id 
    join
        mission_hash_tag ht1_0 
            on m1_0.id=ht1_0.mission_id 
    join
        member m2_0 
            on m2_0.id=d1_0.member_id 
    join
        discussion_hash_tag ht2_0 
            on d1_0.id=ht2_0.discussion_id 
    join
        hash_tag ht3_0 
            on ht3_0.id=ht2_0.hash_tag_id 
    where
        d1_0.id=? 
    order by
        ht2_0.discussion_id,
        ht2_0.hash_tag_id,
        ht1_0.id
```
- N + 1 문제가 발생하지는 않지만 디스커션 조회가 안되는 문제 발생
![image](https://github.com/user-attachments/assets/2f048bbc-4651-482a-a090-7549c1a77f93)
- 전부 LEFT JOIN FETCH로 변경
```java
@Query("""  
        SELECT d        
        FROM Discussion d  
        LEFT JOIN FETCH d.mission m  
        LEFT JOIN FETCH m.missionHashTags.hashTags mhts  
        LEFT JOIN FETCH d.member me  
        LEFT JOIN FETCH d.discussionHashTags.hashTags dhts  
        LEFT JOIN FETCH dhts.hashTag ht  
        WHERE d.id = :id  
        """)
        Optional<Discussion> findFetchById(Long id);
```
- 전부 조회 성공
![image](https://github.com/user-attachments/assets/12240ba7-3d08-41ae-9333-4706c3947ec9)
#### 특정 회원이 제출한 디스커션 목록 조회
```java
@Query("""  
        SELECT d        
        FROM Discussion d  
        JOIN FETCH d.mission m  
        JOIN FETCH d.member me  
        JOIN FETCH d.discussionHashTags.hashTags dhts  
        JOIN FETCH dhts.hashTag ht  
        WHERE me.id = :memberId  
        """)
        List<Discussion> findAllByMemberId(Long memberId);
```
- 단 건 조회와 동일하게 JOIN FETCH 적용 ➡️ 미션이나 해시태그 없으면 조회되지 않음
- 확인을 위해 테스트 코드에 미션이 없거나 해시태그가 없거나 둘 다 없는 경우 추가
```java
Discussion discussionByMember1_1 = DiscussionTestData.defaultDiscussion()  
        .withMission(mission)  
        .withMember(member1)  
        .withHashTags(List.of(hashTag))  
        .build();  
Discussion discussionByMember1_2 = DiscussionTestData.defaultDiscussion()  
        .withMission(null)  
        .withMember(member1)  
        .withHashTags(List.of(hashTag))  
        .build();  
Discussion discussionByMember1_3 = DiscussionTestData.defaultDiscussion()  
        .withMission(mission)  
        .withMember(member1)  
        .withHashTags(Collections.emptyList())  
        .build();  
Discussion discussionByMember1_4 = DiscussionTestData.defaultDiscussion()  
        .withMission(null)  
        .withMember(member1)  
        .withHashTags(Collections.emptyList())  
        .build();
```
- 예외 발생
![image](https://github.com/user-attachments/assets/bafc207a-256f-430e-90cc-3dba5ff85a6f)
- LEFT JOIN으로 변경
```java
@Query("""  
        SELECT d        
        FROM Discussion d  
        LEFT JOIN FETCH d.mission m  
        LEFT JOIN FETCH d.member me  
        LEFT JOIN FETCH d.discussionHashTags.hashTags dhts  
        LEFT JOIN FETCH dhts.hashTag ht  
        WHERE me.id = :memberId  
        """)
        List<Discussion> findAllByMemberId(Long memberId);
```
- 성공
![image](https://github.com/user-attachments/assets/becb2f13-5694-4db6-9880-46dc1335b831)

#### 연관 이슈

- close #588

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
