### PR TITLE
솔루션 댓글에 Querydsl 적용 (issue #606)

### DIFF
--- a/backend/src/main/java/develup/application/solution/comment/SolutionCommentReadService.java
+++ b/backend/src/main/java/develup/application/solution/comment/SolutionCommentReadService.java
@@ -3,12 +3,12 @@ package develup.application.solution.comment;
 import java.util.List;
 import develup.api.exception.DevelupException;
 import develup.api.exception.ExceptionType;
-import develup.domain.solution.SolutionRepository;
 import develup.domain.solution.SolutionRepositoryCustom;
 import develup.domain.solution.comment.MySolutionComment;
 import develup.domain.solution.comment.SolutionComment;
 import develup.domain.solution.comment.SolutionCommentCounts;
 import develup.domain.solution.comment.SolutionCommentRepository;
+import develup.domain.solution.comment.SolutionCommentRepositoryCustom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,8 +20,8 @@ public class SolutionCommentReadService {
 
     private final CommentGroupingService commentGroupingService;
     private final SolutionCommentRepository solutionCommentRepository;
-    private final SolutionRepository solutionRepository;
     private final SolutionRepositoryCustom solutionRepositoryCustom;
+    private final SolutionCommentRepositoryCustom solutionCommentRepositoryCustom;
 
     public SolutionComment getById(Long commentId) {
         SolutionComment comment = solutionCommentRepository.findById(commentId)
@@ -35,13 +35,15 @@ public class SolutionCommentReadService {
     }
 
     public List<SolutionCommentRepliesResponse> getCommentsWithReplies(Long solutionId) {
-        List<SolutionComment> comments = solutionCommentRepository.findAllBySolutionIdOrderByCreatedAtAsc(solutionId);
+        List<SolutionComment> comments = solutionCommentRepositoryCustom
+                .findAllBySolutionIdOrderByCreatedAtAsc(solutionId);
 
         return commentGroupingService.groupReplies(comments);
     }
 
     public List<MySolutionCommentResponse> getMyComments(Long memberId) {
-        List<MySolutionComment> mySolutionComments = solutionCommentRepository.findAllMySolutionComment(memberId);
+        List<MySolutionComment> mySolutionComments = solutionCommentRepositoryCustom
+                .findAllMySolutionComment(memberId);
         SolutionCommentCounts solutionCommentCounts = new SolutionCommentCounts(
                 solutionRepositoryCustom.findAllSolutionCommentCounts()
         );

--- a/backend/src/main/java/develup/domain/solution/comment/SolutionCommentRepository.java
+++ b/backend/src/main/java/develup/domain/solution/comment/SolutionCommentRepository.java
@@ -1,28 +1,6 @@
 package develup.domain.solution.comment;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
 public interface SolutionCommentRepository extends JpaRepository<SolutionComment, Long> {
-
-    @Query("""
-            SELECT sc
-            FROM SolutionComment sc
-            JOIN FETCH sc.member
-            WHERE sc.solution.id = :solutionId
-            ORDER BY sc.createdAt ASC
-            """)
-    List<SolutionComment> findAllBySolutionIdOrderByCreatedAtAsc(Long solutionId);
-
-    @Query("""
-            SELECT new develup.domain.solution.comment.MySolutionComment(
-                sc.id, sc.solution.id, sc.content, sc.createdAt, s.title.value
-            )
-            FROM SolutionComment sc
-            JOIN sc.solution s
-            JOIN sc.member m
-            WHERE sc.member.id = :memberId AND sc.deletedAt IS NULL
-            """)
-    List<MySolutionComment> findAllMySolutionComment(Long memberId);
 }

--- a/backend/src/main/java/develup/domain/solution/comment/SolutionCommentRepositoryCustom.java
+++ b/backend/src/main/java/develup/domain/solution/comment/SolutionCommentRepositoryCustom.java
@@ -1,0 +1,43 @@
+package develup.domain.solution.comment;
+
+import static develup.domain.member.QMember.member;
+import static develup.domain.solution.comment.QSolutionComment.solutionComment;
+
+import java.util.List;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SolutionCommentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<SolutionComment> findAllBySolutionIdOrderByCreatedAtAsc(Long solutionId) {
+        return queryFactory
+                .selectFrom(solutionComment)
+                .join(solutionComment.member, member).fetchJoin()
+                .where(solutionComment.solution.id.eq(solutionId))
+                .orderBy(solutionComment.createdAt.asc())
+                .fetch();
+    }
+
+    public List<MySolutionComment> findAllMySolutionComment(Long memberId) {
+        return queryFactory
+                .select(Projections.constructor(MySolutionComment.class,
+                        solutionComment.id,
+                        solutionComment.solution.id,
+                        solutionComment.content,
+                        solutionComment.createdAt,
+                        solutionComment.solution.title.value
+                ))
+                .from(solutionComment)
+                .join(solutionComment.solution)
+                .join(solutionComment.member)
+                .where(solutionComment.member.id.eq(memberId).and(solutionComment.deletedAt.isNull()))
+                .fetch();
+
+    }
+}

--- a/backend/src/test/java/develup/application/solution/SolutionWriteServiceTest.java
+++ b/backend/src/test/java/develup/application/solution/SolutionWriteServiceTest.java
@@ -16,6 +16,7 @@ import develup.domain.solution.Solution;
 import develup.domain.solution.SolutionRepository;
 import develup.domain.solution.comment.SolutionComment;
 import develup.domain.solution.comment.SolutionCommentRepository;
+import develup.domain.solution.comment.SolutionCommentRepositoryCustom;
 import develup.support.IntegrationTestSupport;
 import develup.support.data.MemberTestData;
 import develup.support.data.MissionTestData;
@@ -35,6 +36,9 @@ class SolutionWriteServiceTest extends IntegrationTestSupport {
 
     @Autowired
     private SolutionCommentRepository solutionCommentRepository;
+
+    @Autowired
+    private SolutionCommentRepositoryCustom solutionCommentRepositoryCustom;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -256,7 +260,7 @@ class SolutionWriteServiceTest extends IntegrationTestSupport {
 
         solutionWriteService.delete(member.getId(), solution.getId());
 
-        List<SolutionComment> comments = solutionCommentRepository.findAllBySolutionIdOrderByCreatedAtAsc(solution.getId());
+        List<SolutionComment> comments = solutionCommentRepositoryCustom.findAllBySolutionIdOrderByCreatedAtAsc(solution.getId());
         Optional<Solution> deletedSolution = solutionRepository.findById(solution.getId());
         assertThat(comments).isEmpty();
         assertThat(deletedSolution).isEmpty();

--- a/backend/src/test/java/develup/domain/solution/comment/SolutionCommentRepositoryCustomTest.java
+++ b/backend/src/test/java/develup/domain/solution/comment/SolutionCommentRepositoryCustomTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-class SolutionCommentRepositoryTest extends IntegrationTestSupport {
+class SolutionCommentRepositoryCustomTest extends IntegrationTestSupport {
 
     @Autowired
     private SolutionRepository solutionRepository;
@@ -34,6 +34,27 @@ class SolutionCommentRepositoryTest extends IntegrationTestSupport {
     @Autowired
     private SolutionCommentRepository solutionCommentRepository;
 
+    @Autowired
+    private SolutionCommentRepositoryCustom solutionCommentRepositoryCustom;
+
+    @Test
+    @DisplayName("특정 솔루션에 작성된 댓글 목록을 생성일자 오름차순으로 조회한다.")
+    void findAllBySolutionIdOrderByCreatedAtAsc() {
+        Member member = createMember();
+
+        Solution otherSolution = createSolution();
+        createSolutionComment(otherSolution, member);
+
+        Solution targetSolution = createSolution();
+        SolutionComment comment1 = createSolutionComment(targetSolution, member);
+        SolutionComment comment2 = createSolutionComment(targetSolution, member);
+
+        List<SolutionComment> solutionComments = solutionCommentRepositoryCustom
+                .findAllBySolutionIdOrderByCreatedAtAsc(targetSolution.getId());
+
+        assertThat(solutionComments).containsExactly(comment1, comment2);
+    }
+
     @Test
     @DisplayName("특정 회원이 작성한 댓글 목록을 조회한다.")
     void getMyComments() {
@@ -46,7 +67,7 @@ class SolutionCommentRepositoryTest extends IntegrationTestSupport {
         }
         createSolutionComment();
 
-        List<MySolutionComment> myComments = solutionCommentRepository.findAllMySolutionComment(member.getId());
+        List<MySolutionComment> myComments = solutionCommentRepositoryCustom.findAllMySolutionComment(member.getId());
 
         assertThat(myComments)
                 .hasSize(solutionComments.size());
@@ -65,7 +86,7 @@ class SolutionCommentRepositoryTest extends IntegrationTestSupport {
         createSolutionComment();
         createDeletedSolutionComment(solution, member);
 
-        List<MySolutionComment> myComments = solutionCommentRepository.findAllMySolutionComment(member.getId());
+        List<MySolutionComment> myComments = solutionCommentRepositoryCustom.findAllMySolutionComment(member.getId());
 
         assertThat(myComments)
                 .hasSize(solutionComments.size());


### PR DESCRIPTION
#### 구현 요약

솔루션 댓글에 Querydsl 적용

RepositoryCustom 때문에 필드 의존성이 늘어가는 것은 어쩔 수 없는 것 같습니다.
아니면 다른 방법으로 repository에 다 넣을 수도 있겠지요. 그러나 이 방법은 파일이 많이 생기겠지요.

Querydsl에서 MySolutionComment같은 dto를 응답하기 위해서 Projections를 사용했습니다.
하지만 이 방법은 컴파일 타임에 오류를 잡을 수 없습니다. `@QueryProjection`을 사용하면 파라미터 개수나 타입을 체크할 수 있지만 record에서는 생성자를 더 만들어야 합니다. 또한 dto에 Querydsl 의존성이 강화될 수 있습니다. [@QueryProejction 참고](https://doing7.tistory.com/129)

#### 연관 이슈

- close #606 

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
