### PR TITLE
솔루션 Querydsl 적용

### DIFF
--- a/backend/src/main/java/develup/application/solution/SolutionReadService.java
+++ b/backend/src/main/java/develup/application/solution/SolutionReadService.java
@@ -5,6 +5,7 @@ import develup.api.exception.DevelupException;
 import develup.api.exception.ExceptionType;
 import develup.domain.solution.Solution;
 import develup.domain.solution.SolutionRepository;
+import develup.domain.solution.SolutionRepositoryCustom;
 import develup.domain.solution.SolutionStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,9 +17,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class SolutionReadService {
 
     private final SolutionRepository solutionRepository;
+    private final SolutionRepositoryCustom solutionRepositoryCustom;
 
     public SolutionResponse getById(Long id) {
-        Solution solution = solutionRepository.findFetchById(id)
+        Solution solution = solutionRepositoryCustom.findFetchById(id)
                 .orElseThrow(() -> new DevelupException(ExceptionType.SOLUTION_NOT_FOUND));
 
         return SolutionResponse.from(solution);
@@ -33,11 +35,11 @@ public class SolutionReadService {
 
     public List<SummarizedSolutionResponse> getCompletedSummaries(String hashTagName) {
         if (hashTagName.equalsIgnoreCase("all")) {
-            return solutionRepository.findAllCompletedSolution().stream()
+            return solutionRepositoryCustom.findAllCompletedSolution().stream()
                     .map(SummarizedSolutionResponse::from)
                     .toList();
         }
-        return solutionRepository.findAllCompletedSolutionByHashTagName(hashTagName).stream()
+        return solutionRepositoryCustom.findAllCompletedSolutionByHashTagName(hashTagName).stream()
                 .map(SummarizedSolutionResponse::from)
                 .toList();
     }

--- a/backend/src/main/java/develup/application/solution/SolutionWriteService.java
+++ b/backend/src/main/java/develup/application/solution/SolutionWriteService.java
@@ -8,6 +8,7 @@ import develup.domain.member.Member;
 import develup.domain.mission.Mission;
 import develup.domain.solution.Solution;
 import develup.domain.solution.SolutionRepository;
+import develup.domain.solution.SolutionRepositoryCustom;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SolutionWriteService {
 
     private final SolutionRepository solutionRepository;
+    private final SolutionRepositoryCustom solutionRepositoryCustom;
     private final SolutionReadService solutionReadService;
     private final MissionReadService missionReadService;
     private final MemberReadService memberReadService;
@@ -64,7 +66,7 @@ public class SolutionWriteService {
         Solution solution = solutionReadService.getSolution(solutionId);
         validateSolutionOwner(memberId, solution);
 
-        solutionRepository.deleteAllComments(solution.getId());
+        solutionRepositoryCustom.deleteAllComments(solution.getId());
         solutionRepository.delete(solution);
     }
 

--- a/backend/src/main/java/develup/application/solution/comment/SolutionCommentReadService.java
+++ b/backend/src/main/java/develup/application/solution/comment/SolutionCommentReadService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import develup.api.exception.DevelupException;
 import develup.api.exception.ExceptionType;
 import develup.domain.solution.SolutionRepository;
+import develup.domain.solution.SolutionRepositoryCustom;
 import develup.domain.solution.comment.MySolutionComment;
 import develup.domain.solution.comment.SolutionComment;
 import develup.domain.solution.comment.SolutionCommentCounts;
@@ -20,6 +21,7 @@ public class SolutionCommentReadService {
     private final CommentGroupingService commentGroupingService;
     private final SolutionCommentRepository solutionCommentRepository;
     private final SolutionRepository solutionRepository;
+    private final SolutionRepositoryCustom solutionRepositoryCustom;
 
     public SolutionComment getById(Long commentId) {
         SolutionComment comment = solutionCommentRepository.findById(commentId)
@@ -41,7 +43,7 @@ public class SolutionCommentReadService {
     public List<MySolutionCommentResponse> getMyComments(Long memberId) {
         List<MySolutionComment> mySolutionComments = solutionCommentRepository.findAllMySolutionComment(memberId);
         SolutionCommentCounts solutionCommentCounts = new SolutionCommentCounts(
-                solutionRepository.findAllSolutionCommentCounts()
+                solutionRepositoryCustom.findAllSolutionCommentCounts()
         );
 
         return mySolutionComments.stream()

--- a/backend/src/main/java/develup/domain/solution/SolutionRepository.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionRepository.java
@@ -2,76 +2,13 @@ package develup.domain.solution;
 
 import java.util.List;
 import java.util.Optional;
-import develup.domain.solution.comment.SolutionCommentCount;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 public interface SolutionRepository extends JpaRepository<Solution, Long> {
 
     boolean existsByMember_IdAndMission_IdAndStatus(Long memberId, Long missionId, SolutionStatus status);
 
-    @Query("""
-            SELECT s
-            FROM Solution s
-            JOIN FETCH s.mission m
-            JOIN FETCH m.missionHashTags.hashTags mhts
-            JOIN FETCH mhts.hashTag ht
-            WHERE
-                s.status = 'COMPLETED' AND
-                EXISTS (
-                   SELECT 1
-                   FROM MissionHashTag smht
-                   JOIN smht.hashTag sht
-                   WHERE
-                       smht.mission.id = m.id AND sht.name = :name
-               )
-            ORDER BY s.id DESC
-            """)
-    List<Solution> findAllCompletedSolutionByHashTagName(String name);
-
-    @Query("""
-            SELECT s
-            FROM Solution s
-            JOIN FETCH s.mission m
-            JOIN FETCH m.missionHashTags.hashTags mhts
-            JOIN FETCH mhts.hashTag ht
-            WHERE s.status = 'COMPLETED'
-            ORDER BY s.id DESC
-            """)
-    List<Solution> findAllCompletedSolution();
-
     List<Solution> findAllByMember_IdAndStatus(Long memberId, SolutionStatus status);
 
-    @Query("""
-            SELECT s
-            FROM Solution s
-            JOIN FETCH s.member mem
-            JOIN FETCH s.mission m
-            JOIN FETCH m.missionHashTags.hashTags mhts
-            JOIN FETCH mhts.hashTag ht
-            WHERE s.id = :solutionId
-            """)
-    Optional<Solution> findFetchById(Long solutionId);
-
     Optional<Solution> findByMember_IdAndMission_IdAndStatus(Long memberId, Long missionId, SolutionStatus status);
-
-    @Query("""
-            DELETE FROM SolutionComment sc
-            WHERE sc.solution.id = :solutionId
-            """)
-    @Modifying(clearAutomatically = true)
-    void deleteAllComments(Long solutionId);
-
-    @Query("""
-            SELECT new develup.domain.solution.comment.SolutionCommentCount(
-                s.id, count(sc)
-            )
-            FROM Solution s
-            JOIN SolutionComment sc
-            ON sc.solution.id = s.id
-            WHERE sc.deletedAt IS NULL AND sc.parentCommentId IS NULL
-            GROUP BY s.id
-            """)
-    List<SolutionCommentCount> findAllSolutionCommentCounts();
 }

--- a/backend/src/main/java/develup/domain/solution/SolutionRepositoryCustom.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionRepositoryCustom.java
@@ -1,0 +1,84 @@
+package develup.domain.solution;
+
+import static develup.domain.member.QMember.member;
+import static develup.domain.mission.QMission.mission;
+import static develup.domain.mission.QMissionHashTag.missionHashTag;
+import static develup.domain.solution.QSolution.solution;
+import static develup.domain.solution.comment.QSolutionComment.solutionComment;
+
+import java.util.List;
+import java.util.Optional;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import develup.domain.solution.comment.SolutionCommentCount;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SolutionRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<Solution> findAllCompletedSolutionByHashTagName(String name) {
+        return queryFactory.selectFrom(solution)
+                .join(solution.mission, mission).fetchJoin()
+                .join(mission.missionHashTags.hashTags, missionHashTag).fetchJoin()
+                .join(missionHashTag.hashTag).fetchJoin()
+                .where(
+                        solution.status.eq(SolutionStatus.COMPLETED)
+                                .and(JPAExpressions.selectOne()
+                                        .from(missionHashTag)
+                                        .join(missionHashTag.hashTag)
+                                        .where(
+                                                missionHashTag.mission.id.eq(mission.id)
+                                                        .and(missionHashTag.hashTag.name.eq(name))
+                                        )
+                                        .exists()
+                                )
+                )
+                .orderBy(solution.id.desc())
+                .fetch();
+    }
+
+    public List<Solution> findAllCompletedSolution() {
+        return queryFactory.selectFrom(solution)
+                .join(solution.mission, mission).fetchJoin()
+                .join(mission.missionHashTags.hashTags, missionHashTag).fetchJoin()
+                .join(missionHashTag.hashTag).fetchJoin()
+                .where(solution.status.eq(SolutionStatus.COMPLETED))
+                .orderBy(solution.id.desc())
+                .fetch();
+    }
+
+    public Optional<Solution> findFetchById(Long solutionId) {
+        return Optional.ofNullable(queryFactory.selectFrom(solution)
+                .join(solution.member, member).fetchJoin()
+                .join(solution.mission, mission).fetchJoin()
+                .join(mission.missionHashTags.hashTags, missionHashTag).fetchJoin()
+                .join(missionHashTag.hashTag).fetchJoin()
+                .where(solution.id.eq(solutionId))
+                .fetchOne()
+        );
+    }
+
+    public void deleteAllComments(Long solutionId) {
+        queryFactory.delete(solutionComment)
+                .where(solutionComment.solution.id.eq(solutionId))
+                .execute();
+    }
+
+    public List<SolutionCommentCount> findAllSolutionCommentCounts() {
+        return queryFactory.select(Projections.constructor(
+                        SolutionCommentCount.class,
+                        solution.id,
+                        solutionComment.count()
+                )).from(solution)
+                .join(solutionComment)
+                .on(solutionComment.solution.id.eq(solution.id))
+                .where(solutionComment.deletedAt.isNull().and(solutionComment.parentCommentId.isNull()))
+                .groupBy(solution.id)
+                .fetch();
+    }
+}

--- a/backend/src/test/java/develup/domain/solution/SolutionRepositoryCustomTest.java
+++ b/backend/src/test/java/develup/domain/solution/SolutionRepositoryCustomTest.java
@@ -1,0 +1,130 @@
+package develup.domain.solution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import develup.domain.hashtag.HashTag;
+import develup.domain.hashtag.HashTagRepository;
+import develup.domain.member.Member;
+import develup.domain.member.MemberRepository;
+import develup.domain.mission.Mission;
+import develup.domain.mission.MissionHashTag;
+import develup.domain.mission.MissionRepository;
+import develup.support.IntegrationTestSupport;
+import develup.support.data.HashTagTestData;
+import develup.support.data.MemberTestData;
+import develup.support.data.MissionTestData;
+import develup.support.data.SolutionTestData;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class SolutionRepositoryCustomTest extends IntegrationTestSupport {
+
+    @Autowired
+    private SolutionRepositoryCustom solutionRepositoryCustom;
+
+    @Autowired
+    private SolutionRepository solutionRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MissionRepository missionRepository;
+
+    @Autowired
+    private HashTagRepository hashTagRepository;
+
+    @Test
+    @DisplayName("주어진 해시태그가 포함된 완료된 솔루션을 조회할 수 있다.")
+    void findAllCompletedSolutionByHashTag() {
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("JAVA").build());
+        Mission mission1 = missionRepository.save(MissionTestData.defaultMission().withHashTags(List.of(hashTag)).build());
+        Mission mission2 = missionRepository.save(MissionTestData.defaultMission().build());
+        Solution solution1 = SolutionTestData.defaultSolution()
+                .withMember(member)
+                .withMission(mission1)
+                .withStatus(SolutionStatus.COMPLETED)
+                .build();
+        Solution solution2 = SolutionTestData.defaultSolution()
+                .withMember(member)
+                .withMission(mission2)
+                .withStatus(SolutionStatus.COMPLETED)
+                .build();
+
+        solutionRepository.saveAll(List.of(solution1, solution2));
+
+        List<Solution> solutions = solutionRepositoryCustom.findAllCompletedSolutionByHashTagName("JAVA");
+
+        assertThat(solutions)
+                .map(Solution::getHashTags)
+                .flatMap(Function.identity())
+                .map(MissionHashTag::getHashTag)
+                .contains(hashTag);
+    }
+
+    @Test
+    @DisplayName("완료된 솔루션을 조회할 수 있다.")
+    void findAllCompletedSolution() {
+        createSolution(SolutionStatus.COMPLETED);
+        createSolution(SolutionStatus.COMPLETED);
+        createSolution(SolutionStatus.IN_PROGRESS);
+
+        List<Solution> actual = solutionRepositoryCustom.findAllCompletedSolution();
+
+        assertThat(actual).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("해시태그가 존재하는 미션에 대한 솔루션을 식별자로 조회한다.")
+    void findFetchById() {
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
+        Mission hashTaggedMission = MissionTestData.defaultMission()
+                .withHashTags(List.of(hashTag))
+                .build();
+        Mission nonTaggedMission = MissionTestData.defaultMission().build();
+        missionRepository.saveAll(List.of(hashTaggedMission, nonTaggedMission));
+
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        Solution hashTaggedSolution = SolutionTestData.defaultSolution()
+                .withMission(hashTaggedMission)
+                .withMember(member)
+                .build();
+        Solution nonTaggedSolution = SolutionTestData.defaultSolution()
+                .withMission(nonTaggedMission)
+                .withMember(member)
+                .build();
+        solutionRepository.saveAll(List.of(hashTaggedSolution, nonTaggedSolution));
+
+        Optional<Solution> hashTaggedFound = solutionRepositoryCustom.findFetchById(hashTaggedSolution.getId());
+        Optional<Solution> noneTaggedFound = solutionRepositoryCustom.findFetchById(nonTaggedSolution.getId());
+
+        Assertions.assertAll(
+                () -> assertThat(hashTaggedFound)
+                        .isPresent()
+                        .map(it -> it.getHashTags().size())
+                        .hasValue(1),
+                () -> assertThat(noneTaggedFound).isEmpty()
+        );
+    }
+
+    private void createSolution(SolutionStatus status) {
+        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("A").build());
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        Mission mission = MissionTestData.defaultMission().withHashTags(List.of(hashTag)).build();
+        missionRepository.save(mission);
+
+        Solution solution = SolutionTestData.defaultSolution()
+                .withMember(member)
+                .withMission(mission)
+                .withStatus(status)
+                .build();
+
+        solutionRepository.save(solution);
+    }
+}

--- a/backend/src/test/java/develup/domain/solution/SolutionRepositoryTest.java
+++ b/backend/src/test/java/develup/domain/solution/SolutionRepositoryTest.java
@@ -5,20 +5,17 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import develup.domain.hashtag.HashTag;
 import develup.domain.hashtag.HashTagRepository;
 import develup.domain.member.Member;
 import develup.domain.member.MemberRepository;
 import develup.domain.mission.Mission;
-import develup.domain.mission.MissionHashTag;
 import develup.domain.mission.MissionRepository;
 import develup.support.IntegrationTestSupport;
 import develup.support.data.HashTagTestData;
 import develup.support.data.MemberTestData;
 import develup.support.data.MissionTestData;
 import develup.support.data.SolutionTestData;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,39 +33,6 @@ class SolutionRepositoryTest extends IntegrationTestSupport {
 
     @Autowired
     private HashTagRepository hashTagRepository;
-
-    @Test
-    @DisplayName("해시태그가 존재하는 미션에 대한 솔루션을 식별자로 조회한다.")
-    void findFetchById() {
-        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
-        Mission hashTaggedMission = MissionTestData.defaultMission()
-                .withHashTags(List.of(hashTag))
-                .build();
-        Mission nonTaggedMission = MissionTestData.defaultMission().build();
-        missionRepository.saveAll(List.of(hashTaggedMission, nonTaggedMission));
-
-        Member member = memberRepository.save(MemberTestData.defaultMember().build());
-        Solution hashTaggedSolution = SolutionTestData.defaultSolution()
-                .withMission(hashTaggedMission)
-                .withMember(member)
-                .build();
-        Solution nonTaggedSolution = SolutionTestData.defaultSolution()
-                .withMission(nonTaggedMission)
-                .withMember(member)
-                .build();
-        solutionRepository.saveAll(List.of(hashTaggedSolution, nonTaggedSolution));
-
-        Optional<Solution> hashTaggedFound = solutionRepository.findFetchById(hashTaggedSolution.getId());
-        Optional<Solution> noneTaggedFound = solutionRepository.findFetchById(nonTaggedSolution.getId());
-
-        Assertions.assertAll(
-                () -> assertThat(hashTaggedFound)
-                        .isPresent()
-                        .map(it -> it.getHashTags().size())
-                        .hasValue(1),
-                () -> assertThat(noneTaggedFound).isEmpty()
-        );
-    }
 
     @Test
     @DisplayName("멤버 식별자와 미션 식별자와 특정 상태에 해당하는 솔루션이 존재하는지 확인한다. ")
@@ -100,47 +64,6 @@ class SolutionRepositoryTest extends IntegrationTestSupport {
                 () -> assertThat(exists).isTrue(),
                 () -> assertThat(notExists).isFalse()
         );
-    }
-
-    @Test
-    @DisplayName("완료된 솔루션을 조회할 수 있다.")
-    void findAllCompletedSolution() {
-        createSolution(SolutionStatus.COMPLETED);
-        createSolution(SolutionStatus.COMPLETED);
-        createSolution(SolutionStatus.IN_PROGRESS);
-
-        List<Solution> actual = solutionRepository.findAllCompletedSolution();
-
-        assertThat(actual).hasSize(2);
-    }
-
-    @Test
-    @DisplayName("주어진 해시태그가 포함된 완료된 솔루션을 조회할 수 있다.")
-    void findAllCompletedSolutionByHashTag() {
-        Member member = memberRepository.save(MemberTestData.defaultMember().build());
-        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("JAVA").build());
-        Mission mission1 = missionRepository.save(MissionTestData.defaultMission().withHashTags(List.of(hashTag)).build());
-        Mission mission2 = missionRepository.save(MissionTestData.defaultMission().build());
-        Solution solution1 = SolutionTestData.defaultSolution()
-                .withMember(member)
-                .withMission(mission1)
-                .withStatus(SolutionStatus.COMPLETED)
-                .build();
-        Solution solution2 = SolutionTestData.defaultSolution()
-                .withMember(member)
-                .withMission(mission2)
-                .withStatus(SolutionStatus.COMPLETED)
-                .build();
-
-        solutionRepository.saveAll(List.of(solution1, solution2));
-
-        List<Solution> solutions = solutionRepository.findAllCompletedSolutionByHashTagName("JAVA");
-
-        assertThat(solutions)
-                .map(Solution::getHashTags)
-                .flatMap(Function.identity())
-                .map(MissionHashTag::getHashTag)
-                .contains(hashTag);
     }
 
     @Test


### PR DESCRIPTION
#### 구현 요약

솔루션 Querydsl 적용
SolutionRepositoryCustom 을 두어서 Querydsl 만 모아두었어요.

그리고.. deleteAllComments 쿼리는 테스트가 없길래 추가하려고 했는데 solutionCommentRepository 에서 save 하고 solutionRepositoryCustom 에서 지우니까 영속성 컨텍스트가 공유되지 않아서 그런건지 한 테스트 내에서 확인할 방법을 잘 모르겠습니다.

```
@Test
    @DisplayName("솔루션 댓글을 모두 지운다.")
    @Transactional
    void deleteAllComments() {
        HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().build());
        Member member = memberRepository.save(MemberTestData.defaultMember().build());
        Mission mission = MissionTestData.defaultMission().withHashTags(List.of(hashTag)).build();
        missionRepository.save(mission);
        Solution solution = SolutionTestData.defaultSolution().withId(1L).withMember(member)
                .withMission(mission)
                .build();
        SolutionComment comment = SolutionCommentTestData.defaultSolutionComment()
                .withSolution(solution)
                .withMember(member)
                .build();
        solutionRepository.save(solution);
        solutionCommentRepository.save(comment);

        solutionRepositoryCustom.deleteAllComments(solution.getId());
        
        assertThat(solutionCommentRepository.findById(comment.getId())).isEmpty(); // 있다고 나옴
    }
```

#### 연관 이슈

- close #609 

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
