### PR TITLE
디스커션 QueryDSL 적용 (issue #608)

### DIFF
--- a/backend/src/main/java/develup/application/discussion/DiscussionReadService.java
+++ b/backend/src/main/java/develup/application/discussion/DiscussionReadService.java
@@ -4,7 +4,7 @@ import java.util.List;
 import develup.api.exception.DevelupException;
 import develup.api.exception.ExceptionType;
 import develup.domain.discussion.Discussion;
-import develup.domain.discussion.DiscussionRepository;
+import develup.domain.discussion.DiscussionRepositoryCustom;
 import develup.domain.discussion.comment.DiscussionCommentCounts;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,12 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class DiscussionReadService {
 
-    private final DiscussionRepository discussionRepository;
+    private final DiscussionRepositoryCustom discussionRepositoryCustom;
 
     public List<SummarizedDiscussionResponse> getSummaries(String mission, String hashTagName) {
-        List<Discussion> discussions = discussionRepository.findAllByMissionAndHashTagName(mission, hashTagName);
+        List<Discussion> discussions = discussionRepositoryCustom.findAllByMissionAndHashTagName(mission, hashTagName);
         DiscussionCommentCounts discussionCommentCounts = new DiscussionCommentCounts(
-                discussionRepository.findAllDiscussionCommentCounts()
+                discussionRepositoryCustom.findAllDiscussionCommentCounts()
         );
 
         return discussions.stream()
@@ -32,9 +32,9 @@ public class DiscussionReadService {
     }
 
     public List<SummarizedDiscussionResponse> getDiscussionsByMemberId(Long memberId) {
-        List<Discussion> myDiscussions = discussionRepository.findAllByMemberId(memberId);
+        List<Discussion> myDiscussions = discussionRepositoryCustom.findAllByMemberId(memberId);
         DiscussionCommentCounts discussionCommentCounts = new DiscussionCommentCounts(
-                discussionRepository.findAllDiscussionCommentCounts()
+                discussionRepositoryCustom.findAllDiscussionCommentCounts()
         );
 
         return myDiscussions.stream()
@@ -52,7 +52,7 @@ public class DiscussionReadService {
     }
 
     public Discussion getDiscussion(Long id) {
-        return discussionRepository.findFetchById(id)
+        return discussionRepositoryCustom.findFetchById(id)
                 .orElseThrow(() -> new DevelupException(ExceptionType.DISCUSSION_NOT_FOUND));
     }
 

--- a/backend/src/main/java/develup/application/discussion/DiscussionWriteService.java
+++ b/backend/src/main/java/develup/application/discussion/DiscussionWriteService.java
@@ -7,6 +7,7 @@ import develup.application.member.MemberReadService;
 import develup.application.mission.MissionReadService;
 import develup.domain.discussion.Discussion;
 import develup.domain.discussion.DiscussionRepository;
+import develup.domain.discussion.DiscussionRepositoryCustom;
 import develup.domain.discussion.DiscussionTitle;
 import develup.domain.hashtag.HashTag;
 import develup.domain.hashtag.HashTagRepository;
@@ -26,6 +27,7 @@ public class DiscussionWriteService {
     private final MemberReadService memberReadService;
     private final MissionReadService missionReadService;
     private final HashTagRepository hashTagRepository;
+    private final DiscussionRepositoryCustom discussionRepositoryCustom;
 
     public DiscussionResponse create(Long memberId, CreateDiscussionRequest request) {
         Mission mission = getMission(request.missionId());
@@ -107,7 +109,7 @@ public class DiscussionWriteService {
         Discussion discussion = discussionReadService.getDiscussion(discussionId);
         validateDiscussionOwner(memberId, discussion);
 
-        discussionRepository.deleteAllComments(discussionId);
+        discussionRepositoryCustom.deleteAllComments(discussionId);
         discussionRepository.deleteById(discussionId);
     }
 }

--- a/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentReadService.java
+++ b/backend/src/main/java/develup/application/discussion/comment/DiscussionCommentReadService.java
@@ -3,7 +3,7 @@ package develup.application.discussion.comment;
 import java.util.List;
 import develup.api.exception.DevelupException;
 import develup.api.exception.ExceptionType;
-import develup.domain.discussion.DiscussionRepository;
+import develup.domain.discussion.DiscussionRepositoryCustom;
 import develup.domain.discussion.comment.DiscussionComment;
 import develup.domain.discussion.comment.DiscussionCommentCounts;
 import develup.domain.discussion.comment.DiscussionCommentRepository;
@@ -21,7 +21,7 @@ public class DiscussionCommentReadService {
     private final DiscussionCommentGroupingService commentGroupingService;
     private final DiscussionCommentRepositoryCustom discussionCommentRepositoryCustom;
     private final DiscussionCommentRepository discussionCommentRepository;
-    private final DiscussionRepository discussionRepository;
+    private final DiscussionRepositoryCustom discussionRepositoryCustom;
 
     public DiscussionComment getById(Long commentId) {
         DiscussionComment comment = discussionCommentRepository.findById(commentId)
@@ -43,7 +43,7 @@ public class DiscussionCommentReadService {
     public List<MyDiscussionCommentResponse> getMyComments(Long memberId) {
         List<MyDiscussionComment> mySolutionComments = discussionCommentRepositoryCustom.findAllMyDiscussionComment(memberId);
         DiscussionCommentCounts discussionCommentCounts = new DiscussionCommentCounts(
-                discussionRepository.findAllDiscussionCommentCounts()
+                discussionRepositoryCustom.findAllDiscussionCommentCounts()
         );
 
         return mySolutionComments.stream()

--- a/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
@@ -1,15 +1,7 @@
 package develup.domain.discussion;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
 
-    @Query("""
-            DELETE FROM DiscussionComment dc
-            WHERE dc.discussion.id = :discussionId
-            """)
-    @Modifying(clearAutomatically = true)
-    void deleteAllComments(Long discussionId);
 }

--- a/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionRepository.java
@@ -1,72 +1,10 @@
 package develup.domain.discussion;
 
-import java.util.List;
-import java.util.Optional;
-import develup.domain.discussion.comment.DiscussionCommentCount;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface DiscussionRepository extends JpaRepository<Discussion, Long> {
-
-    @Query("""
-            SELECT d
-            FROM Discussion d
-            LEFT JOIN FETCH d.mission m
-            LEFT JOIN FETCH d.discussionHashTags.hashTags dhts
-            LEFT JOIN FETCH dhts.hashTag ht
-            WHERE
-                ((:mission = null) OR LOWER(:mission) = 'all' OR m.title = :mission)
-                AND
-                ((:hashTag = null) OR LOWER(:hashTag) = 'all' OR EXISTS (
-                    SELECT 1
-                    FROM DiscussionHashTag dht
-                    JOIN dht.hashTag sht
-                    WHERE dht.discussion.id = d.id
-                    AND sht.name = :hashTag
-                ))
-            ORDER BY d.id DESC
-            """)
-    List<Discussion> findAllByMissionAndHashTagName(
-            @Param("mission") String mission,
-            @Param("hashTag") String hashTagName
-    );
-
-    @Query("""
-            SELECT d
-            FROM Discussion d
-            LEFT JOIN FETCH d.mission m
-            LEFT JOIN FETCH m.missionHashTags.hashTags mhts
-            LEFT JOIN FETCH d.member me
-            LEFT JOIN FETCH d.discussionHashTags.hashTags dhts
-            LEFT JOIN FETCH dhts.hashTag ht
-            WHERE d.id = :id
-            """)
-    Optional<Discussion> findFetchById(Long id);
-
-    @Query("""
-            SELECT d
-            FROM Discussion d
-            LEFT JOIN FETCH d.mission m
-            LEFT JOIN FETCH d.member me
-            LEFT JOIN FETCH d.discussionHashTags.hashTags dhts
-            LEFT JOIN FETCH dhts.hashTag ht
-            WHERE me.id = :memberId
-            """)
-    List<Discussion> findAllByMemberId(Long memberId);
-
-    @Query("""
-            SELECT new develup.domain.discussion.comment.DiscussionCommentCount(
-                d.id, count(dc)
-            )
-            FROM Discussion d
-            JOIN FETCH DiscussionComment dc
-            ON dc.discussion.id = d.id
-            WHERE dc.deletedAt IS NULL AND dc.parentCommentId IS NULL
-            GROUP BY d.id
-            """)
-    List<DiscussionCommentCount> findAllDiscussionCommentCounts();
 
     @Query("""
             DELETE FROM DiscussionComment dc

--- a/backend/src/main/java/develup/domain/discussion/DiscussionRepositoryCustom.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionRepositoryCustom.java
@@ -1,0 +1,92 @@
+package develup.domain.discussion;
+
+import static develup.domain.discussion.QDiscussion.discussion;
+import static develup.domain.discussion.QDiscussionHashTag.discussionHashTag;
+import static develup.domain.discussion.comment.QDiscussionComment.discussionComment;
+import static develup.domain.hashtag.QHashTag.hashTag;
+import static develup.domain.member.QMember.member;
+import static develup.domain.mission.QMission.mission;
+import static develup.domain.mission.QMissionHashTag.missionHashTag;
+
+import java.util.List;
+import java.util.Optional;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import develup.domain.discussion.comment.DiscussionCommentCount;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DiscussionRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    public List<Discussion> findAllByMissionAndHashTagName(String missionTitle, String hashTagName) {
+        return queryFactory
+                .selectFrom(discussion)
+                .innerJoin(discussion.member, member).fetchJoin()
+                .leftJoin(discussion.mission, mission).fetchJoin()
+                .leftJoin(discussion.discussionHashTags.hashTags, discussionHashTag).fetchJoin()
+                .leftJoin(discussionHashTag.hashTag, hashTag).fetchJoin()
+                .where(filterByMissionName(missionTitle), filterByHashTagName(hashTagName))
+                .orderBy(discussion.id.desc())
+                .fetch();
+    }
+
+    private BooleanExpression filterByMissionName(String missionTitle) {
+        if (missionTitle == null || "all".equalsIgnoreCase(missionTitle)) {
+            return null;
+        }
+
+        return mission.title.eq(missionTitle);
+    }
+
+    private BooleanExpression filterByHashTagName(String hashTagName) {
+        if (hashTagName == null || "all".equalsIgnoreCase(hashTagName)) {
+            return null;
+        }
+
+        return discussionHashTag.hashTag.name.eq(hashTagName)
+                .and(discussionHashTag.discussion.id.eq(discussion.id));
+    }
+
+    public Optional<Discussion> findFetchById(Long id) {
+        Discussion result = queryFactory
+                .selectFrom(discussion)
+                .innerJoin(discussion.member, member).fetchJoin()
+                .leftJoin(discussion.mission, mission).fetchJoin()
+                .leftJoin(mission.missionHashTags.hashTags, missionHashTag).fetchJoin()
+                .leftJoin(discussion.discussionHashTags.hashTags, discussionHashTag).fetchJoin()
+                .leftJoin(discussionHashTag.hashTag, hashTag).fetchJoin()
+                .where(discussion.id.eq(id))
+                .fetchOne();
+        return Optional.ofNullable(result);
+    }
+
+    public List<Discussion> findAllByMemberId(Long memberId) {
+        return queryFactory
+                .selectFrom(discussion)
+                .innerJoin(discussion.member, member).fetchJoin()
+                .leftJoin(discussion.mission, mission).fetchJoin()
+                .leftJoin(discussion.discussionHashTags.hashTags, discussionHashTag).fetchJoin()
+                .leftJoin(discussionHashTag.hashTag, hashTag).fetchJoin()
+                .where(member.id.eq(memberId))
+                .fetch();
+    }
+
+    public List<DiscussionCommentCount> findAllDiscussionCommentCounts() {
+        return queryFactory
+                .select(Projections.constructor(DiscussionCommentCount.class,
+                        discussion.id.as("id"),
+                        discussionComment.id.count().as("count")
+                ))
+                .from(discussion)
+                .join(discussionComment)
+                .on(discussionComment.discussion.id.eq(discussion.id))
+                .where(discussionComment.deletedAt.isNull(), discussionComment.parentCommentId.isNull())
+                .groupBy(discussion.id)
+                .fetch();
+    }
+}

--- a/backend/src/main/java/develup/domain/discussion/DiscussionRepositoryCustom.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionRepositoryCustom.java
@@ -14,6 +14,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import develup.domain.discussion.comment.DiscussionCommentCount;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -22,6 +23,7 @@ import org.springframework.stereotype.Repository;
 public class DiscussionRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final EntityManager entityManager;
 
     public List<Discussion> findAllByMissionAndHashTagName(String missionTitle, String hashTagName) {
         return queryFactory
@@ -88,5 +90,15 @@ public class DiscussionRepositoryCustom {
                 .where(discussionComment.deletedAt.isNull(), discussionComment.parentCommentId.isNull())
                 .groupBy(discussion.id)
                 .fetch();
+    }
+
+    public void deleteAllComments(Long discussionId) {
+        queryFactory
+                .delete(discussionComment)
+                .where(discussionComment.discussion.id.eq(discussionId))
+                .execute();
+
+        entityManager.flush();
+        entityManager.clear();
     }
 }

--- a/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryCustomTest.java
+++ b/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryCustomTest.java
@@ -26,10 +26,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
-public class DiscussionRepositoryTest extends IntegrationTestSupport {
+public class DiscussionRepositoryCustomTest extends IntegrationTestSupport {
 
     @Autowired
     private DiscussionRepository discussionRepository;
+
+    @Autowired
+    private DiscussionRepositoryCustom discussionRepositoryCustom;
 
     @Autowired
     private DiscussionCommentRepository discussionCommentRepository;
@@ -56,7 +59,7 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         createDiscussion(mission, Collections.emptyList());
         createDiscussion(null, Collections.emptyList());
 
-        List<Discussion> actual = discussionRepository.findAllByMissionAndHashTagName(
+        List<Discussion> actual = discussionRepositoryCustom.findAllByMissionAndHashTagName(
                 "all",
                 "all"
         );
@@ -74,7 +77,7 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         createDiscussion(mission, List.of(hashTag1));
         createDiscussion(mission, List.of(hashTag2));
 
-        List<Discussion> discussions = discussionRepository.findAllByMissionAndHashTagName(
+        List<Discussion> discussions = discussionRepositoryCustom.findAllByMissionAndHashTagName(
                 "all",
                 "JAVA"
         );
@@ -96,7 +99,7 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         createDiscussion(mission1, List.of(hashTag));
         createDiscussion(mission2, List.of(hashTag));
 
-        List<Discussion> discussions = discussionRepository.findAllByMissionAndHashTagName(
+        List<Discussion> discussions = discussionRepositoryCustom.findAllByMissionAndHashTagName(
                 "루터회관 흡연단속",
                 "all"
         );
@@ -120,7 +123,7 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
                 .build();
         Discussion savedDiscussion = discussionRepository.save(discussion);
 
-        assertThat(discussionRepository.findFetchById(savedDiscussion.getId()))
+        assertThat(discussionRepositoryCustom.findFetchById(savedDiscussion.getId()))
                 .map(Discussion::getId)
                 .hasValue(savedDiscussion.getId());
     }
@@ -138,7 +141,7 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
                 .build();
         Discussion savedDiscussion = discussionRepository.save(discussion);
 
-        assertThat(discussionRepository.findFetchById(savedDiscussion.getId()))
+        assertThat(discussionRepositoryCustom.findFetchById(savedDiscussion.getId()))
                 .map(Discussion::getId)
                 .hasValue(savedDiscussion.getId());
     }
@@ -156,7 +159,7 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
                 .build();
         Discussion savedDiscussion = discussionRepository.save(discussion);
 
-        assertThat(discussionRepository.findFetchById(savedDiscussion.getId()))
+        assertThat(discussionRepositoryCustom.findFetchById(savedDiscussion.getId()))
                 .map(Discussion::getId)
                 .hasValue(savedDiscussion.getId());
     }
@@ -173,7 +176,7 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
                 .build();
         Discussion savedDiscussion = discussionRepository.save(discussion);
 
-        assertThat(discussionRepository.findFetchById(savedDiscussion.getId()))
+        assertThat(discussionRepositoryCustom.findFetchById(savedDiscussion.getId()))
                 .map(Discussion::getId)
                 .hasValue(savedDiscussion.getId());
     }
@@ -181,7 +184,7 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
     @Test
     @DisplayName("멤버 식별자를 통해 디스커션을 조회한다.")
     @Transactional
-    void findByMember_Id() {
+    void findByMemberId() {
         Member member1 = memberRepository.save(MemberTestData.defaultMember().withId(1L).build());
         Member member2 = memberRepository.save(MemberTestData.defaultMember().withId(2L).build());
         Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
@@ -219,8 +222,8 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         discussionRepository.save(discussionByMember1_4);
         discussionRepository.save(discussionByMember2);
 
-        List<Discussion> discussionsByMember1 = discussionRepository.findAllByMemberId(member1.getId());
-        List<Discussion> discussionsByMember2 = discussionRepository.findAllByMemberId(member2.getId());
+        List<Discussion> discussionsByMember1 = discussionRepositoryCustom.findAllByMemberId(member1.getId());
+        List<Discussion> discussionsByMember2 = discussionRepositoryCustom.findAllByMemberId(member2.getId());
 
         assertAll(
                 () -> assertThat(discussionsByMember1).hasSize(4),
@@ -242,7 +245,7 @@ public class DiscussionRepositoryTest extends IntegrationTestSupport {
         saveDeletedDiscussionComment(savedDiscussion, member);
 
         DiscussionCommentCounts discussionCommentCounts = new DiscussionCommentCounts(
-                discussionRepository.findAllDiscussionCommentCounts()
+                discussionRepositoryCustom.findAllDiscussionCommentCounts()
         );
         Long count = discussionCommentCounts.getCount(savedDiscussion);
 

--- a/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryCustomTest.java
+++ b/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryCustomTest.java
@@ -301,7 +301,7 @@ public class DiscussionRepositoryCustomTest extends IntegrationTestSupport {
 
         DiscussionComment discussionComment = saveDiscussionComment(discussion, member);
 
-        discussionRepository.deleteAllComments(discussion.getId());
+        discussionRepositoryCustom.deleteAllComments(discussion.getId());
 
         assertThat(discussionCommentRepository.findById(discussionComment.getId())).isEmpty();
     }


### PR DESCRIPTION
#### 구현 요약

동적 쿼리에서 `BooleanExpression`을 사용해서 필터링하지 않아도 될 때(들어온 값이 null이거나 `all`인 경우) null이 리턴되어 where 절이 생성되지 않도록 했습니다.
🚨 QueryDSL 적용하고 궁금해서 간단하게 시간 재는 방식으로 성능 테스트를 해봤는데 QueryDSL을 사용한 쪽이 대부분 성능이 더 느려졌습니다. 우선은 적용하기로 합의 했으니 적용했지만 성능 관련해서는 다시 논의가 필요할 것 같습니다.
자세한 내용은 아래 참고해주세요.

---

> 앞 쪽에 이름은 테스트 코드 메서드 이름이고 레파지토리 메서드 실행 전후로 시간 찍어서 비교했어요.
### 목록 조회
- 기존 : findAllDiscussion executed in 39 ms
- 변경 : findAllDiscussion executed in 67 ms
- 기존 : findAllByMissionAndHashTagName executed in 45 ms
- 변경 : findAllByMissionAndHashTagName executed in 70 ms
- 기존 : findAllDiscussionByMission executed in 42 ms
- 변경 : findAllDiscussionByMission executed in 57 ms

### 단 건 조회
- 기존 : findFetchById executed in 40 ms
- 변경 : findFetchById executed in 56 ms

### 멤버 아이디 조회
- 기존 : findByMemberId executed in 9 ms
- 변경 : findByMemberId executed in 2 ms


### 댓글 개수 조회
- 기존 : findAllDiscussionCommentCounts executed in 30 ms
- 변경 : findAllDiscussionCommentCounts executed in 84 ms

#### 기존
<img width="706" alt="image" src="https://github.com/user-attachments/assets/c6aa0354-c3bd-48cb-992b-c3a73816a78e">

#### 변경
<img width="701" alt="image" src="https://github.com/user-attachments/assets/f87bbdd1-c651-46ea-a5bc-ef37e463434b">

#### 연관 이슈

- close #608

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
