### PR TITLE
풀이 태그 버그 해결 (issue #661)

### DIFF
--- a/frontend/src/apis/solutions.ts
+++ b/frontend/src/apis/solutions.ts
@@ -1,6 +1,5 @@
 import { develupAPIClient } from '@/apis/clients/develupClient';
 import { PATH } from '@/apis/paths';
-import { HASHTAGS } from '@/constants/hashTags';
 import type { HashTag } from '@/types';
 import type { Solution, SubmittedSolution } from '@/types/solution';
 

--- a/frontend/src/pages/SolutionListPage/index.tsx
+++ b/frontend/src/pages/SolutionListPage/index.tsx
@@ -12,7 +12,7 @@ export default function SolutionListPage() {
   const [selectedHashTag, setSelectedHashTag] = useState<{ id: number; name: string } | null>(null);
 
   const { data: allHashTags } = useHashTags();
-  const { data: allMissions } = useMissions(selectedHashTag?.name);
+  const { data: allMissions } = useMissions();
 
   return (
     <S.SolutionListPageContainer>


### PR DESCRIPTION
#### 구현 요약

풀이 태그 버그를 해결했습니다.

#### 버그 상황

풀이 리스트에서 특정 해시 태그 클릭 시, 미션 태그 리스트가 함께 변화되는 현상이 있었습니다. 해당 해시태그와 관련있는 미션만 리스트로 출력이 되었습니다.

- 해시태그 선택 전
![image](https://github.com/user-attachments/assets/883033ab-79b4-4693-9961-7da290394e7c)

- 해시태그 선택 후
![스크린샷 145551](https://github.com/user-attachments/assets/47278b1f-c652-4fe9-9faa-e5d801e88a09)

#### 원인 및 해결 방법

- 풀이 리스트에서 미션 태그 리스트에 쓰이는 `useMissions`의 props로 선택된 해시태그의 name이 전달되고 있는 것을 발견했습니다. 따라서 해시태그가 선택될 때마다 관련 있는 미션만 리스트로 호출해왔던 것이었습니다.
- 따라서 이 props를 제거하는 것으로 해결했습니다.

#### 연관 이슈

- close #661

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
