### PR TITLE
솔루션, 디스커션 목록 조회 할 때 해시태그 필터링 시 조회 결과에 해당 해시태그만 표시되는 버그 수정(issue #674)

### DIFF
--- a/backend/src/main/java/develup/domain/discussion/DiscussionRepositoryCustom.java
+++ b/backend/src/main/java/develup/domain/discussion/DiscussionRepositoryCustom.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import develup.domain.discussion.comment.DiscussionCommentCount;
 import jakarta.persistence.EntityManager;
@@ -50,8 +51,14 @@ public class DiscussionRepositoryCustom {
             return null;
         }
 
-        return discussionHashTag.hashTag.name.eq(hashTagName)
-                .and(discussionHashTag.discussion.id.eq(discussion.id));
+        return JPAExpressions.selectOne()
+                .from(discussionHashTag)
+                .join(discussionHashTag.hashTag)
+                .where(
+                        discussionHashTag.discussion.id.eq(discussion.id),
+                        discussionHashTag.hashTag.name.eq(hashTagName)
+                )
+                .exists();
     }
 
     public Optional<Discussion> findFetchById(Long id) {

--- a/backend/src/main/java/develup/domain/solution/SolutionRepositoryCustom.java
+++ b/backend/src/main/java/develup/domain/solution/SolutionRepositoryCustom.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import develup.domain.solution.comment.SolutionCommentCount;
 import jakarta.persistence.EntityManager;
@@ -28,7 +29,11 @@ public class SolutionRepositoryCustom {
                 .join(solution.mission, mission).fetchJoin()
                 .join(mission.missionHashTags.hashTags, missionHashTag).fetchJoin()
                 .join(missionHashTag.hashTag).fetchJoin()
-                .where(eqCompleted(), eqMissionTitle(missionTitle), eqHashTagName(hashTagName))
+                .where(
+                        eqCompleted(),
+                        eqMissionTitle(missionTitle),
+                        eqHashTagName(hashTagName)
+                )
                 .orderBy(solution.submittedAt.desc())
                 .fetch();
     }
@@ -50,7 +55,14 @@ public class SolutionRepositoryCustom {
             return null;
         }
 
-        return missionHashTag.hashTag.name.eq(hashTagName);
+        return JPAExpressions.selectOne()
+                .from(missionHashTag)
+                .join(missionHashTag.hashTag)
+                .where(
+                        missionHashTag.mission.id.eq(mission.id),
+                        missionHashTag.hashTag.name.eq(hashTagName)
+                )
+                .exists();
     }
 
     public Optional<Solution> findFetchById(Long solutionId) {

--- a/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryCustomTest.java
+++ b/backend/src/test/java/develup/domain/discussion/DiscussionRepositoryCustomTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
 import develup.domain.discussion.comment.DiscussionComment;
 import develup.domain.discussion.comment.DiscussionCommentCounts;
 import develup.domain.discussion.comment.DiscussionCommentRepository;
@@ -74,8 +73,8 @@ public class DiscussionRepositoryCustomTest extends IntegrationTestSupport {
         Mission mission = missionRepository.save(MissionTestData.defaultMission().build());
         HashTag hashTag1 = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("JAVA").build());
         HashTag hashTag2 = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("객체지향").build());
-        createDiscussion(mission, List.of(hashTag1));
-        createDiscussion(mission, List.of(hashTag2));
+        Discussion discussion = createDiscussion(mission, List.of(hashTag1));
+        Discussion withOut = createDiscussion(mission, List.of(hashTag2));
 
         List<Discussion> discussions = discussionRepositoryCustom.findAllByMissionAndHashTagName(
                 "all",
@@ -83,10 +82,8 @@ public class DiscussionRepositoryCustomTest extends IntegrationTestSupport {
         );
 
         assertThat(discussions)
-                .map(Discussion::getDiscussionHashTags)
-                .flatMap(Function.identity())
-                .map(DiscussionHashTag::getHashTag)
-                .contains(hashTag1);
+                .containsExactly(discussion)
+                .doesNotContain(withOut);
     }
 
     @Test
@@ -96,8 +93,8 @@ public class DiscussionRepositoryCustomTest extends IntegrationTestSupport {
         Mission mission1 = missionRepository.save(MissionTestData.defaultMission().withTitle("루터회관 흡연단속").build());
         Mission mission2 = missionRepository.save(MissionTestData.defaultMission().withTitle("주문").build());
         HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("JAVA").build());
-        createDiscussion(mission1, List.of(hashTag));
-        createDiscussion(mission2, List.of(hashTag));
+        Discussion discussion = createDiscussion(mission1, List.of(hashTag));
+        Discussion without = createDiscussion(mission2, List.of(hashTag));
 
         List<Discussion> discussions = discussionRepositoryCustom.findAllByMissionAndHashTagName(
                 "루터회관 흡연단속",
@@ -105,8 +102,8 @@ public class DiscussionRepositoryCustomTest extends IntegrationTestSupport {
         );
 
         assertThat(discussions)
-                .map(Discussion::getMission)
-                .contains(mission1);
+                .containsExactly(discussion)
+                .doesNotContain(without);
     }
 
     @Test
@@ -260,7 +257,7 @@ public class DiscussionRepositoryCustomTest extends IntegrationTestSupport {
         assertThat(count).isEqualTo(1);
     }
 
-    private void createDiscussion(Mission mission, List<HashTag> hashTags) {
+    private Discussion createDiscussion(Mission mission, List<HashTag> hashTags) {
         Member member = memberRepository.save(MemberTestData.defaultMember().build());
 
         Discussion discussion = DiscussionTestData.defaultDiscussion()
@@ -269,7 +266,7 @@ public class DiscussionRepositoryCustomTest extends IntegrationTestSupport {
                 .withHashTags(hashTags)
                 .build();
 
-        discussionRepository.save(discussion);
+        return discussionRepository.save(discussion);
     }
 
     private Discussion getSavedDiscussion(Mission mission, Member member, HashTag hashTag) {

--- a/backend/src/test/java/develup/domain/solution/SolutionRepositoryCustomTest.java
+++ b/backend/src/test/java/develup/domain/solution/SolutionRepositoryCustomTest.java
@@ -1,6 +1,7 @@
 package develup.domain.solution;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -21,7 +22,6 @@ import develup.support.data.MemberTestData;
 import develup.support.data.MissionTestData;
 import develup.support.data.SolutionCommentTestData;
 import develup.support.data.SolutionTestData;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,12 +48,59 @@ public class SolutionRepositoryCustomTest extends IntegrationTestSupport {
     private HashTagRepository hashTagRepository;
 
     @Test
+    @DisplayName("솔루션 목록 조회 시 연관관계가 모두 조회된다.")
+    void findAllCompletedSolutionWithRelations() {
+        Member member = memberRepository.save(MemberTestData.defaultMember().build());
+        HashTag java = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("JAVA").build());
+        HashTag oop = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("OOP").build());
+        Mission mission1 = createMissionWithHashTags(java, oop);
+        Mission mission2 = createMissionWithHashTags(java);
+        Solution solution1 = SolutionTestData.defaultSolution()
+                .withMember(member)
+                .withMission(mission1)
+                .withStatus(SolutionStatus.COMPLETED)
+                .withSubmittedAt(LocalDateTime.of(2024, 1, 1, 0, 0))
+                .build();
+        Solution solution2 = SolutionTestData.defaultSolution()
+                .withMember(member)
+                .withMission(mission2)
+                .withStatus(SolutionStatus.COMPLETED)
+                .withSubmittedAt(LocalDateTime.of(2024, 1, 2, 0, 0))
+                .build();
+
+        solutionRepository.saveAll(List.of(solution1, solution2));
+
+        List<Solution> solutions = solutionRepositoryCustom.findAllCompletedSolutionByHashTagName("all", "JAVA");
+
+        assertAll(
+                () -> {
+                    List<HashTag> hashTags = solutions.getFirst().getHashTags()
+                            .stream()
+                            .map(MissionHashTag::getHashTag)
+                            .toList();
+                    assertThat(hashTags).containsExactly(java);
+                },
+                () -> {
+                    List<HashTag> hashTags = solutions.get(1).getHashTags()
+                            .stream()
+                            .map(MissionHashTag::getHashTag)
+                            .toList();
+                    assertThat(hashTags).containsExactly(java, oop);
+                }
+        );
+    }
+
+    private Mission createMissionWithHashTags(HashTag... hashTags) {
+        return missionRepository.save(MissionTestData.defaultMission().withHashTags(List.of(hashTags)).build());
+    }
+
+    @Test
     @DisplayName("솔루션을 제출일자 역순으로 조회할 수 있다.")
     void findAllCompletedSolutionByHashTagOrderBySubmittedAtDesc() {
         Member member = memberRepository.save(MemberTestData.defaultMember().build());
         HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("JAVA").build());
-        Mission mission1 = missionRepository.save(MissionTestData.defaultMission().withHashTags(List.of(hashTag)).build());
-        Mission mission2 = missionRepository.save(MissionTestData.defaultMission().withHashTags(List.of(hashTag)).build());
+        Mission mission1 = createMissionWithHashTags(hashTag);
+        Mission mission2 = createMissionWithHashTags(hashTag);
         Solution solution1 = SolutionTestData.defaultSolution()
                 .withMember(member)
                 .withMission(mission1)
@@ -82,8 +129,8 @@ public class SolutionRepositoryCustomTest extends IntegrationTestSupport {
         Member member = memberRepository.save(MemberTestData.defaultMember().build());
         HashTag hashTag1 = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("JAVA").build());
         HashTag hashTag2 = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("JS").build());
-        Mission mission1 = missionRepository.save(MissionTestData.defaultMission().withHashTags(List.of(hashTag1)).build());
-        Mission mission2 = missionRepository.save(MissionTestData.defaultMission().withHashTags(List.of(hashTag2)).build());
+        Mission mission1 = createMissionWithHashTags(hashTag1);
+        Mission mission2 = createMissionWithHashTags(hashTag2);
         Solution solution1 = SolutionTestData.defaultSolution()
                 .withMember(member)
                 .withMission(mission1)
@@ -111,7 +158,7 @@ public class SolutionRepositoryCustomTest extends IntegrationTestSupport {
     void findAllCompletedSolutionByMissionName() {
         Member member = memberRepository.save(MemberTestData.defaultMember().build());
         HashTag hashTag = hashTagRepository.save(HashTagTestData.defaultHashTag().withName("JAVA").build());
-        Mission otherMission = missionRepository.save(MissionTestData.defaultMission().withHashTags(List.of(hashTag)).build());
+        Mission otherMission = createMissionWithHashTags(hashTag);
         Mission targetMission = missionRepository.save(MissionTestData.defaultMission().withHashTags(List.of(hashTag)).withTitle("테스트 미션 제목").build());
         Solution otherSolution = SolutionTestData.defaultSolution()
                 .withMember(member)
@@ -169,7 +216,7 @@ public class SolutionRepositoryCustomTest extends IntegrationTestSupport {
         Optional<Solution> hashTaggedFound = solutionRepositoryCustom.findFetchById(hashTaggedSolution.getId());
         Optional<Solution> noneTaggedFound = solutionRepositoryCustom.findFetchById(nonTaggedSolution.getId());
 
-        Assertions.assertAll(
+        assertAll(
                 () -> assertThat(hashTaggedFound)
                         .isPresent()
                         .map(it -> it.getHashTags().size())


### PR DESCRIPTION
#### 구현 요약

서브쿼리를 다시 추가하여 제대로 조회되도록 수정했습니다.

테스트에서 이를 효과적으로 검증하는 방식을 추천해주세요.

#### 연관 이슈

- close #674

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
