### PR TITLE
풀이/디스커션 제출 페이지 마크다운 에디터 적용 (issue #683)

### DIFF
--- a/frontend/src/components/DiscussionList/DiscussionListContent.tsx
+++ b/frontend/src/components/DiscussionList/DiscussionListContent.tsx
@@ -1,14 +1,20 @@
 import * as S from './DiscussionList.styled';
 import DiscussionListItem from './DiscussionListItem';
 import { Link } from 'react-router-dom';
-import type { Discussion } from '@/types';
 import NoContentWithoutButton from '../common/NoContent/NoContentWithoutButton';
+import useDiscussions from '@/hooks/useDiscussions';
 
 interface DiscussionListContentProps {
-  discussions: Discussion[];
+  missionTitle?: string;
+  hashtag?: string;
 }
 
-export default function DiscussionListContent({ discussions }: DiscussionListContentProps) {
+export default function DiscussionListContent({
+  missionTitle,
+  hashtag,
+}: DiscussionListContentProps) {
+  const { data: discussions } = useDiscussions(missionTitle, hashtag);
+
   return (
     <S.ContentContainer>
       {discussions.length ? (

--- a/frontend/src/components/DiscussionSubmit/DiscussionDescription.tsx
+++ b/frontend/src/components/DiscussionSubmit/DiscussionDescription.tsx
@@ -1,21 +1,28 @@
-import TextArea from '@/components/common/TextArea/TextArea';
+import MarkdownEditor from '../common/MarkdownEditor/MarkdownEditor';
 import * as S from './DiscussionSubmit.styled';
-import type { TextareaHTMLAttributes } from 'react';
 
-interface DiscussionDescriptionProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+interface DiscussionDescriptionProps {
+  value: string;
+  onChange: (v?: string) => void;
   danger: boolean;
   dangerMessage: string;
 }
 
 export default function DiscussionDescription({
+  value,
+  onChange,
   danger,
   dangerMessage,
-  ...props
 }: DiscussionDescriptionProps) {
   return (
     <S.DiscussionDescriptionContainer>
       <S.DiscussionDescriptionTitle>내용</S.DiscussionDescriptionTitle>
-      <TextArea danger={danger} dangerMessage={dangerMessage} {...props} />
+      <MarkdownEditor
+        value={value}
+        onChange={onChange}
+        danger={danger}
+        dangerMessage={dangerMessage}
+      />
     </S.DiscussionDescriptionContainer>
   );
 }

--- a/frontend/src/components/DiscussionSubmit/index.tsx
+++ b/frontend/src/components/DiscussionSubmit/index.tsx
@@ -42,6 +42,7 @@ export default function DiscussionSubmit() {
     discussionTitle,
     isDiscussionTitleError,
     handleDiscussionTitle,
+    handleMarkDownDescription,
     isDescriptionError,
     handleDescription,
     handleSubmitDiscussion,
@@ -120,8 +121,7 @@ export default function DiscussionSubmit() {
           value={description}
           danger={isDescriptionError}
           dangerMessage={ERROR_MESSAGE.no_content}
-          onChange={handleDescription}
-          placeholder="내용을 입력해 주세요."
+          onChange={handleMarkDownDescription}
         />
         <SubmitButton />
       </form>

--- a/frontend/src/components/MissionDetail/MissionDetail.styled.ts
+++ b/frontend/src/components/MissionDetail/MissionDetail.styled.ts
@@ -7,7 +7,7 @@ import SanitizedMDPreview from '../common/SanitizedMDPreview';
 
 // MissionDetailHeader
 
-export const MissionDetailHeaderContainer = styled.div`
+export const MissionDetailHeaderContainer = styled.header`
   width: 100%;
   height: 20rem;
   margin: 0 auto;
@@ -136,7 +136,7 @@ export const SubmitButton = styled.button`
 
 // MissionDetailContent
 
-export const MissionDescription = styled.div`
+export const MissionDescription = styled.section`
   width: 100%;
   padding: 2rem;
 

--- a/frontend/src/components/MissionDetail/MissionDetailHeader.tsx
+++ b/frontend/src/components/MissionDetail/MissionDetailHeader.tsx
@@ -24,9 +24,9 @@ export default function MissionDetailHeader({
           {hashTags &&
             hashTags.map((tag) => {
               return (
-                <TagButton key={tag.id} isClickable={false}>
-                  # {tag.name}
-                </TagButton>
+                <li key={tag.id}>
+                  <TagButton isClickable={false}># {tag.name}</TagButton>
+                </li>
               );
             })}
         </S.HashTagWrapper>

--- a/frontend/src/components/MissionSubmit/OneWord.tsx
+++ b/frontend/src/components/MissionSubmit/OneWord.tsx
@@ -1,16 +1,18 @@
 import * as S from './OneWord.styled';
-import TextArea from '../common/TextArea/TextArea';
-import type { TextareaHTMLAttributes } from 'react';
+import MarkdownEditor from '../common/MarkdownEditor/MarkdownEditor';
 
-interface OneWordProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+interface OneWordProps {
   danger: boolean;
+  dangerMessage?: string;
+  value: string;
+  onChange: (v?: string) => void;
 }
 
-export default function OneWord({ danger, ...props }: OneWordProps) {
+export default function OneWord({ ...props }: OneWordProps) {
   return (
     <S.Container>
       <S.Title>구현 방식에 대한 설명</S.Title>
-      <TextArea danger={danger} {...props} />
+      <MarkdownEditor {...props} />
     </S.Container>
   );
 }

--- a/frontend/src/components/common/Input/Input.styled.ts
+++ b/frontend/src/components/common/Input/Input.styled.ts
@@ -42,7 +42,7 @@ const borderRadiusStyles = {
 
 const typeStyles = {
   default: css`
-    background: ${(props) => props.theme.colors.grey100};
+    background: ${(props) => props.theme.colors.white};
   `,
 };
 
@@ -54,7 +54,7 @@ export const Input = styled.input<InputProps>`
   outline: none;
   padding: 2.3rem;
   border: none;
-  border: 0.15rem solid transparent;
+  border: 0.1rem solid #d0d7de;
 
   &::placeholder {
     color: rgba(0, 0, 0, 0.3);

--- a/frontend/src/components/common/MarkdownEditor/MarkdownEditor.tsx
+++ b/frontend/src/components/common/MarkdownEditor/MarkdownEditor.tsx
@@ -1,0 +1,25 @@
+import * as S from './TextArea.styled';
+
+interface MarkdownEditorProps {
+  type?: 'Default';
+  size?: 'Default';
+  danger?: boolean;
+  dangerMessage?: string;
+  onChange: (v?: string) => void;
+  value: string;
+}
+
+export default function MarkdownEditor({
+  type = 'Default',
+  size = 'Default',
+  danger = false,
+  dangerMessage = '',
+  ...props
+}: MarkdownEditorProps) {
+  return (
+    <>
+      <S.MarkdownEditor $type={type} $size={size} $danger={danger} {...props} />
+      {danger && dangerMessage && <S.DangerText>{dangerMessage}</S.DangerText>}
+    </>
+  );
+}

--- a/frontend/src/components/common/MarkdownEditor/TextArea.styled.ts
+++ b/frontend/src/components/common/MarkdownEditor/TextArea.styled.ts
@@ -1,0 +1,59 @@
+import { styled, css } from 'styled-components';
+import MDEditor from '@uiw/react-md-editor';
+
+interface MarkdownEditorProps {
+  $type: 'Default';
+  $size: 'Default';
+  $danger: boolean;
+}
+
+const sizeStyles = {
+  Default: css`
+    width: 100%;
+    height: 15rem;
+  `,
+};
+
+const typeStyles = {
+  Default: css`
+    background: ${(props) => props.theme.colors.grey100};
+  `,
+};
+
+export const MarkdownEditor = styled(MDEditor)<MarkdownEditorProps>`
+  ${(props) => sizeStyles[props.$size]}
+  ${(props) => typeStyles[props.$type]}
+  outline: none;
+  min-height: 15rem;
+  border-radius: 0.8rem;
+  border: 1px solid transparent;
+  border-bottom: 0.15rem solid transparent;
+
+  ${(props) => props.theme.font.body}
+
+  .w-md-editor-content {
+    padding-left: 1.5rem;
+  }
+
+  &::placeholder {
+    color: rgba(0, 0, 0, 0.3);
+  }
+
+  ${(props) =>
+    props.$danger
+      ? css`
+          border-color: ${(props) => props.theme.colors.danger600};
+        `
+      : css`
+          &:focus {
+            border-color: ${(props) => props.theme.colors.primary500};
+          }
+        `}
+`;
+
+export const DangerText = styled.p`
+  color: ${(props) => props.theme.colors.danger600};
+  ${(props) => props.theme.font.caption}
+  margin-top: 1rem;
+  margin-left: 1rem;
+`;

--- a/frontend/src/components/common/MarkdownEditor/TextArea.styled.ts
+++ b/frontend/src/components/common/MarkdownEditor/TextArea.styled.ts
@@ -55,5 +55,5 @@ export const DangerText = styled.p`
   color: ${(props) => props.theme.colors.danger600};
   ${(props) => props.theme.font.caption}
   margin-top: 1rem;
-  margin-left: 1rem;
+  margin-left: 2.3rem;
 `;

--- a/frontend/src/components/common/Modal/Modal.tsx
+++ b/frontend/src/components/common/Modal/Modal.tsx
@@ -14,7 +14,7 @@ export default function Modal({ children, isModalOpen }: ModalProps) {
       $unMountAnimation={fadeOut}
       $animationTime={300}
     >
-      <ModalWrapper.Portal id="modal">
+      <ModalWrapper.Portal id="modal" aria-modal="true">
         <ModalWrapper.Backdrop opacity="rgba(0, 0, 0, 0.3)">
           <ModalWrapper.Container>{children}</ModalWrapper.Container>
         </ModalWrapper.Backdrop>

--- a/frontend/src/components/common/SpinnerSuspense.tsx
+++ b/frontend/src/components/common/SpinnerSuspense.tsx
@@ -1,0 +1,6 @@
+import { Suspense, type PropsWithChildren } from 'react';
+import LoadingSpinner from './LoadingSpinner/LoadingSpinner';
+
+export default function SpinnerSuspense({ children }: PropsWithChildren) {
+  return <Suspense fallback={<LoadingSpinner />}>{children}</Suspense>;
+}

--- a/frontend/src/hooks/useDescription.ts
+++ b/frontend/src/hooks/useDescription.ts
@@ -19,9 +19,21 @@ const useDescription = () => {
     setIsDescriptionError(false);
   };
 
+  const handleMarkDownDescription = (v: string = '') => {
+    setDescription(v);
+
+    if (v.trim().length === 0) {
+      setIsDescriptionError(true);
+      return;
+    }
+
+    setIsDescriptionError(false);
+  };
+
   return {
     description,
     handleDescription,
+    handleMarkDownDescription,
     isValidDescription,
     setIsDescriptionError,
     isDescriptionError,

--- a/frontend/src/hooks/useSubmitDiscussion.ts
+++ b/frontend/src/hooks/useSubmitDiscussion.ts
@@ -20,6 +20,7 @@ export const useSubmitDiscussion = ({ missionId, hashTagIds }: useSubmitDiscussi
   const {
     description,
     handleDescription,
+    handleMarkDownDescription,
     isValidDescription,
     isDescriptionError,
     setIsDescriptionError,
@@ -51,6 +52,7 @@ export const useSubmitDiscussion = ({ missionId, hashTagIds }: useSubmitDiscussi
   return {
     discussionTitle,
     handleDiscussionTitle,
+    handleMarkDownDescription,
     isValidDiscussionTitle,
     isDiscussionTitleError,
     description,

--- a/frontend/src/hooks/useSubmitSolution.ts
+++ b/frontend/src/hooks/useSubmitSolution.ts
@@ -20,6 +20,7 @@ const useSubmitSolution = ({ missionId }: UseSubmitSolutionParams) => {
   const {
     description,
     handleDescription,
+    handleMarkDownDescription,
     isValidDescription,
     isDescriptionError,
     setIsDescriptionError,
@@ -63,6 +64,7 @@ const useSubmitSolution = ({ missionId }: UseSubmitSolutionParams) => {
     description,
     solutionTitle,
     handleDescription,
+    handleMarkDownDescription,
     handleUrl,
     handleSubmitSolution,
     handleSolutionTitle,

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -89,9 +89,9 @@ const routes = [
       <QueryErrorBoundary>
         <App>
           <SpinnerSuspense>
-            <PrivateRoute redirectTo={ROUTES.login}>
-              <MissionSubmitPage />
-            </PrivateRoute>
+            {/* <PrivateRoute redirectTo={ROUTES.login}> */}
+            <MissionSubmitPage />
+            {/* </PrivateRoute> */}
           </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -89,9 +89,9 @@ const routes = [
       <QueryErrorBoundary>
         <App>
           <SpinnerSuspense>
-            {/* <PrivateRoute redirectTo={ROUTES.login}> */}
-            <MissionSubmitPage />
-            {/* </PrivateRoute> */}
+            <PrivateRoute redirectTo={ROUTES.login}>
+              <MissionSubmitPage />
+            </PrivateRoute>
           </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -4,14 +4,14 @@ import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import GlobalStyle from './styles/GlobalStyle';
 import { ROUTES } from './constants/routes';
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
-import React, { lazy, Suspense } from 'react';
-import LoadingSpinner from './components/common/LoadingSpinner/LoadingSpinner';
+import React, { lazy } from 'react';
 import QueryErrorBoundary from './components/common/Error/QueryErrorBoundary';
 import * as Sentry from '@sentry/react';
 import { ThemeProvider } from 'styled-components';
 import { theme } from './styles/theme';
 import './styles/fonts.css';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import SpinnerSuspense from './components/common/SpinnerSuspense';
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -76,9 +76,9 @@ const routes = [
     element: (
       <QueryErrorBoundary>
         <App>
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <MainPage />
-          </Suspense>
+          </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>
     ),
@@ -88,11 +88,11 @@ const routes = [
     element: (
       <QueryErrorBoundary>
         <App>
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <PrivateRoute redirectTo={ROUTES.login}>
               <MissionSubmitPage />
             </PrivateRoute>
-          </Suspense>
+          </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>
     ),
@@ -102,9 +102,9 @@ const routes = [
     element: (
       <QueryErrorBoundary>
         <App>
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <MissionDetailPage />
-          </Suspense>
+          </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>
     ),
@@ -114,11 +114,11 @@ const routes = [
     element: (
       <QueryErrorBoundary>
         <App>
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <PrivateRoute redirectTo={ROUTES.login}>
               <UserProfilePage />
             </PrivateRoute>
-          </Suspense>
+          </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>
     ),
@@ -138,9 +138,9 @@ const routes = [
     element: (
       <QueryErrorBoundary>
         <App>
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <MissionListPage />
-          </Suspense>
+          </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>
     ),
@@ -150,9 +150,9 @@ const routes = [
     element: (
       <QueryErrorBoundary>
         <App>
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <SolutionListPage />
-          </Suspense>
+          </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>
     ),
@@ -162,9 +162,9 @@ const routes = [
     element: (
       <QueryErrorBoundary>
         <App>
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <DashboardPage />
-          </Suspense>
+          </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>
     ),
@@ -172,41 +172,41 @@ const routes = [
       {
         path: ROUTES.dashboardMissionInProgress,
         element: (
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <DashBoardMissionInProgressPage />
-          </Suspense>
+          </SpinnerSuspense>
         ),
       },
       {
         path: ROUTES.dashboardSubmittedSolution,
         element: (
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <SubmittedSolutionList />
-          </Suspense>
+          </SpinnerSuspense>
         ),
       },
       {
         path: ROUTES.dashboardComments,
         element: (
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <MyCommentsPage />
-          </Suspense>
+          </SpinnerSuspense>
         ),
       },
       {
         path: ROUTES.dashboardDiscussions,
         element: (
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <DashboardDiscussionPage />
-          </Suspense>
+          </SpinnerSuspense>
         ),
       },
       {
         path: ROUTES.dashboardDiscussionComments,
         element: (
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <DashboardDiscussionCommentPage />
-          </Suspense>
+          </SpinnerSuspense>
         ),
       },
     ],
@@ -216,9 +216,9 @@ const routes = [
     element: (
       <QueryErrorBoundary>
         <App>
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <SolutionDetailPage />
-          </Suspense>
+          </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>
     ),
@@ -228,9 +228,9 @@ const routes = [
     element: (
       <QueryErrorBoundary>
         <App>
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <DiscussionDetailPage />
-          </Suspense>
+          </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>
     ),
@@ -240,11 +240,11 @@ const routes = [
     element: (
       <QueryErrorBoundary>
         <App>
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <PrivateRoute redirectTo={ROUTES.login}>
               <DiscussionSubmitPage />
             </PrivateRoute>
-          </Suspense>
+          </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>
     ),
@@ -254,9 +254,9 @@ const routes = [
     element: (
       <QueryErrorBoundary>
         <App>
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <DiscussionListPage />
-          </Suspense>
+          </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>
     ),
@@ -266,9 +266,9 @@ const routes = [
     element: (
       <QueryErrorBoundary>
         <App>
-          <Suspense fallback={<LoadingSpinner />}>
+          <SpinnerSuspense>
             <NeedToLoginPage />
-          </Suspense>
+          </SpinnerSuspense>
         </App>
       </QueryErrorBoundary>
     ),

--- a/frontend/src/pages/DiscussionListPage/index.tsx
+++ b/frontend/src/pages/DiscussionListPage/index.tsx
@@ -2,18 +2,17 @@ import DiscussionListContent from '@/components/DiscussionList/DiscussionListCon
 import * as S from './DiscussionListPage.styled';
 import DiscussionListHeader from '@/components/DiscussionList/DiscussionListHeader';
 import { useState } from 'react';
-import useDiscussions from '@/hooks/useDiscussions';
 import TagList from '@/components/common/TagList';
 import useHashTags from '@/hooks/useHashTags';
 import type { HashTag } from '@/types';
 import useMissions from '@/hooks/useMissions';
 import type { SelectedMissionType } from '@/types/mission';
+import SpinnerSuspense from '@/components/common/SpinnerSuspense';
 
 export default function DiscussionListPage() {
   const [selectedMission, setSelectedMission] = useState<SelectedMissionType | null>(null);
   const [selectedHashTag, setSelectedHashTag] = useState<HashTag | null>(null);
 
-  const { data: discussions } = useDiscussions(selectedMission?.title, selectedHashTag?.name);
   const { data: allHashTags } = useHashTags();
   const { data: allMissions } = useMissions();
 
@@ -35,7 +34,12 @@ export default function DiscussionListPage() {
           keyName="name"
         />
       </S.TagListWrapper>
-      <DiscussionListContent discussions={discussions} />
+      <SpinnerSuspense>
+        <DiscussionListContent
+          missionTitle={selectedMission?.title}
+          hashtag={selectedHashTag?.name}
+        />
+      </SpinnerSuspense>
     </S.DiscussionListPageContainer>
   );
 }

--- a/frontend/src/pages/MissionSubmitPage.tsx
+++ b/frontend/src/pages/MissionSubmitPage.tsx
@@ -7,7 +7,7 @@ import SubmitButton from '@/components/MissionSubmit/SubmitButton';
 import SubmitSuccessPopUp from '@/components/PopUp/SubmitSuccessPopUp';
 import { useParams, useSearchParams } from 'react-router-dom';
 import useMission from '@/hooks/useMission';
-import { PROGRESS_MESSAGE } from '@/constants/messages';
+import { ERROR_MESSAGE } from '@/constants/messages';
 import useSubmitSolution from '@/hooks/useSubmitSolution';
 import LoadingSpinner from '@/components/common/LoadingSpinner/LoadingSpinner';
 import MissionTitle from '@/components/MissionSubmit/MissionTitle';
@@ -33,6 +33,7 @@ export default function MissionSubmitPage() {
     url,
     description,
     handleDescription,
+    handleMarkDownDescription,
     handleUrl,
     handleSubmitSolution,
     handleSolutionTitle,
@@ -103,9 +104,9 @@ export default function MissionSubmitPage() {
         />
         <OneWord
           danger={isDescriptionError}
+          dangerMessage={ERROR_MESSAGE.no_content}
           value={description ?? ''}
-          onChange={handleDescription}
-          placeholder={PROGRESS_MESSAGE.solution_description}
+          onChange={handleMarkDownDescription}
         />
         <SubmitButton />
       </form>

--- a/frontend/src/pages/SolutionListPage/index.tsx
+++ b/frontend/src/pages/SolutionListPage/index.tsx
@@ -2,10 +2,11 @@ import * as S from './SolutionListPage.styled';
 import TagList from '@/components/common/TagList';
 import useHashTags from '@/hooks/useHashTags';
 
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import SolutionList from '@/components/SolutionList';
 import type { SelectedMissionType } from '@/types/mission';
 import useMissions from '@/hooks/useMissions';
+import LoadingSpinner from '@/components/common/LoadingSpinner/LoadingSpinner';
 
 export default function SolutionListPage() {
   const [selectedMission, setSelectedMission] = useState<SelectedMissionType | null>(null);
@@ -33,7 +34,9 @@ export default function SolutionListPage() {
         selectedTag={selectedHashTag}
         keyName="name"
       />
-      <SolutionList selectedMission={selectedMission} selectedHashTag={selectedHashTag} />
+      <Suspense fallback={<LoadingSpinner />}>
+        <SolutionList selectedMission={selectedMission} selectedHashTag={selectedHashTag} />
+      </Suspense>
     </S.SolutionListPageContainer>
   );
 }

--- a/frontend/src/pages/SolutionListPage/index.tsx
+++ b/frontend/src/pages/SolutionListPage/index.tsx
@@ -2,11 +2,11 @@ import * as S from './SolutionListPage.styled';
 import TagList from '@/components/common/TagList';
 import useHashTags from '@/hooks/useHashTags';
 
-import { Suspense, useState } from 'react';
+import { useState } from 'react';
 import SolutionList from '@/components/SolutionList';
 import type { SelectedMissionType } from '@/types/mission';
 import useMissions from '@/hooks/useMissions';
-import LoadingSpinner from '@/components/common/LoadingSpinner/LoadingSpinner';
+import SpinnerSuspense from '@/components/common/SpinnerSuspense';
 
 export default function SolutionListPage() {
   const [selectedMission, setSelectedMission] = useState<SelectedMissionType | null>(null);
@@ -34,9 +34,9 @@ export default function SolutionListPage() {
         selectedTag={selectedHashTag}
         keyName="name"
       />
-      <Suspense fallback={<LoadingSpinner />}>
+      <SpinnerSuspense>
         <SolutionList selectedMission={selectedMission} selectedHashTag={selectedHashTag} />
-      </Suspense>
+      </SpinnerSuspense>
     </S.SolutionListPageContainer>
   );
 }

--- a/frontend/src/styles/GlobalStyle.tsx
+++ b/frontend/src/styles/GlobalStyle.tsx
@@ -222,6 +222,17 @@ body {
     --white-color: #FFFFFF;
     --black-color: #000000;
   }
+  
+/* 모든 요소에 대해 스크롤바 숨기기 */
+* {
+scrollbar-width: none; /* Firefox */
+-ms-overflow-style: none; /* IE and Edge */
+}
+
+/* WebKit 기반 브라우저 (Chrome, Safari) */
+*::-webkit-scrollbar {
+display: none;
+}
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
#### 구현 요약

풀이/디스커션 제출 페이지에 마크다운 에디터 적용합니다.
<img width="933" alt="스크린샷 2024-10-16 오전 10 20 20" src="https://github.com/user-attachments/assets/44448ec4-a8b9-48ce-8274-f572db37446a">

<img width="932" alt="스크린샷 2024-10-16 오전 10 18 57" src="https://github.com/user-attachments/assets/cb4df3af-adb6-4032-ae7d-05f9704e9d6c">

#### 연관 이슈

이 부분을 제거하고 연관된 이슈를 아래와 같이 명시해 닫아주세요.

- close #683

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
