### PR TITLE
QA 개선 사항 반영 (issue #707)

### DIFF
--- a/frontend/src/components/SolutionDetail/SolutionDetailHeader.tsx
+++ b/frontend/src/components/SolutionDetail/SolutionDetailHeader.tsx
@@ -1,6 +1,8 @@
 import type { Solution } from '@/types/solution';
 import * as S from './SolutionDetail.styled';
 import TagButton from '@/components/common/TagButton';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@/constants/routes';
 
 interface SolutionDetailHeaderProps {
   solution: Solution;
@@ -8,6 +10,11 @@ interface SolutionDetailHeaderProps {
 
 export default function SolutionDetailHeader({ solution }: SolutionDetailHeaderProps) {
   const { mission, member, title } = solution;
+
+  const navigate = useNavigate();
+  const navigateToMission = () => {
+    navigate(`${ROUTES.missionDetail}/${solution.mission.id}`);
+  };
 
   return (
     <S.SolutionDetailHeaderContainer
@@ -17,7 +24,9 @@ export default function SolutionDetailHeader({ solution }: SolutionDetailHeaderP
         <S.ThumbnailImg src={mission.thumbnail} alt="" />
         <S.GradientOverlay />
         <S.HeaderLeftArea>
-          <S.MissionTitle># {mission.title}</S.MissionTitle>
+          <TagButton variant="danger" onClick={navigateToMission}>
+            # {mission.title}
+          </TagButton>
           <S.Title>{title}</S.Title>
           <S.HeaderUserInfo>
             <S.HeaderProfileImg src={member.imageUrl} alt="" />

--- a/frontend/src/components/UserProfile/UserProfile.styled.ts
+++ b/frontend/src/components/UserProfile/UserProfile.styled.ts
@@ -1,9 +1,22 @@
-import { styled } from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const show = keyframes`
+  0% {
+    opacity: 0;
+    }
+
+  100% {
+    opacity: 1;
+  }
+`;
 
 export const PageContainer = styled.div`
   width: 50rem;
   height: 50rem;
   margin: 0 auto;
+
+  animation: ${show} 0.5s;
+  transition: 0.5s;
 `;
 
 export const ImageContainer = styled.div`

--- a/frontend/src/components/common/ScrollToTopButton/ScrollToTopButton.styled.ts
+++ b/frontend/src/components/common/ScrollToTopButton/ScrollToTopButton.styled.ts
@@ -1,26 +1,30 @@
 import media from '@/styles/mediaQueries';
 import styled from 'styled-components';
-// import UpArrow from '@/assets/images/upArrow.svg';
 
-export const ScrollButton = styled.button`
-  width: 7rem;
-  height: 7rem;
+interface ScrollButtonProps {
+  $isVisible: boolean;
+}
+
+export const ScrollButton = styled.button<ScrollButtonProps>`
+  width: 5rem;
+  height: 5rem;
   border-radius: 50%;
   background-color: rgba(115, 131, 214, 0.3);
   color: white;
   border: none;
-  padding: 2rem;
+  padding: 1.5rem;
 
   position: fixed;
   bottom: 4.5rem;
   right: 10rem;
   cursor: pointer;
+  pointer-events: ${({ $isVisible }) => ($isVisible ? 'auto' : 'none')};
 
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  opacity: ${({ $isVisible }) => ($isVisible ? 1 : 0)};
   z-index: 1000;
-  transition: background-color 0.2s;
+  transition:
+    opacity 0.2s ease-in,
+    background-color 0.2s ease;
 
   &:hover {
     background-color: rgba(115, 131, 214, 0.5);
@@ -31,10 +35,6 @@ export const ScrollButton = styled.button`
       height: 3rem;
       padding: 1rem;
 
-      right: 5rem;
+      right: 3rem;
     `}
 `;
-
-// export const UpArrowImg = styled(UpArrow)`
-//   w
-// `

--- a/frontend/src/components/common/ScrollToTopButton/index.tsx
+++ b/frontend/src/components/common/ScrollToTopButton/index.tsx
@@ -1,16 +1,11 @@
-import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 import UpArrow from '@/assets/images/upArrow.svg';
 import * as S from './ScrollToTopButton.styled';
 import { useIsFetching } from '@tanstack/react-query';
+import { useScrollVisibility } from '@/hooks/useScrollVisibility';
 
 export function ScrollToTopButton() {
-  const { pathname } = useLocation();
   const isFetching = useIsFetching();
-
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, [pathname]);
+  const isVisible = useScrollVisibility(0);
 
   const handleScrollToTop = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -21,7 +16,7 @@ export function ScrollToTopButton() {
   }
 
   return (
-    <S.ScrollButton onClick={handleScrollToTop}>
+    <S.ScrollButton $isVisible={isVisible} onClick={handleScrollToTop}>
       <UpArrow />
     </S.ScrollButton>
   );

--- a/frontend/src/components/common/TagButton/TagButton.styled.ts
+++ b/frontend/src/components/common/TagButton/TagButton.styled.ts
@@ -62,5 +62,7 @@ export const Button = styled.button<ButtonProps>`
   justify-content: center;
   align-items: center;
 
+  width: fit-content;
+
   ${(props) => props.theme.font.badge}
 `;

--- a/frontend/src/components/common/TagButton/TagButton.styled.ts
+++ b/frontend/src/components/common/TagButton/TagButton.styled.ts
@@ -54,7 +54,7 @@ export const Button = styled.button<ButtonProps>`
       isClickable: props.$isClickable,
       theme: props.theme,
     })};
-  transition: 0.2s;
+  transition: 0.4s;
 
   padding: 1rem 1.6rem;
   border-radius: 2rem;

--- a/frontend/src/hooks/useScrollVisibility.ts
+++ b/frontend/src/hooks/useScrollVisibility.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import { debounce } from '@/utils/debounce';
+
+export function useScrollVisibility(threshold: number = 0) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = debounce(() => {
+      const scrollPosition = window.scrollY;
+
+      if (scrollPosition > threshold) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    }, 200);
+
+    window.addEventListener('scroll', handleScroll);
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, [threshold]);
+
+  return isVisible;
+}

--- a/frontend/src/pages/AboutPage/AboutPage.styled.ts
+++ b/frontend/src/pages/AboutPage/AboutPage.styled.ts
@@ -12,6 +12,7 @@ export const Container = styled.article`
   align-items: center;
   flex-direction: column;
   width: 100%;
+  margin-bottom: 10rem;
 `;
 
 // 로켓 이미지
@@ -155,7 +156,7 @@ export const ComponentContainer = styled.figure<{ $isVisible: boolean }>`
 
   max-width: 120rem;
   width: 89rem;
-  height: 100vh;
+  height: 90vh;
 
   background-color: ${(props) => props.theme.colors.white};
 

--- a/frontend/src/pages/DashboardPage/DashBoardPageLayout/DashBoardPageLayout.styled.ts
+++ b/frontend/src/pages/DashboardPage/DashBoardPageLayout/DashBoardPageLayout.styled.ts
@@ -1,4 +1,14 @@
-import { styled } from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const show = keyframes`
+  0% {
+    opacity: 0;
+    }
+
+  100% {
+    opacity: 1;
+  }
+`;
 
 export const Container = styled.div`
   display: flex;
@@ -7,6 +17,9 @@ export const Container = styled.div`
   margin-bottom: 10rem;
   padding: 3.5rem 0;
   width: 100rem;
+
+  animation: ${show} 0.5s;
+  transition: 0.5s;
 `;
 
 export const ContentWrapper = styled.div`

--- a/frontend/src/pages/DiscussionDetailPage/DiscussionDetailPage.styled.ts
+++ b/frontend/src/pages/DiscussionDetailPage/DiscussionDetailPage.styled.ts
@@ -1,11 +1,24 @@
-import styled from 'styled-components';
 import SanitizedMDPreview from '@/components/common/SanitizedMDPreview';
+import styled, { keyframes } from 'styled-components';
+
+const show = keyframes`
+  0% {
+    opacity: 0;
+    }
+
+  100% {
+    opacity: 1;
+  }
+`;
 
 export const DiscussionDetailPageContainer = styled.div`
   margin: 0 auto;
   width: fit-content;
   padding-bottom: 10rem;
   max-width: 100%;
+
+  animation: ${show} 0.5s;
+  transition: 0.5s;
 `;
 
 export const DiscussionDetailTitle = styled.h1`

--- a/frontend/src/pages/DiscussionListPage/DiscussionListPage.styled.ts
+++ b/frontend/src/pages/DiscussionListPage/DiscussionListPage.styled.ts
@@ -1,4 +1,14 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const show = keyframes`
+  0% {
+    opacity: 0;
+    }
+
+  100% {
+    opacity: 1;
+  }
+`;
 
 export const DiscussionListPageContainer = styled.div`
   display: flex;
@@ -7,6 +17,9 @@ export const DiscussionListPageContainer = styled.div`
   margin: 4.5rem auto 0;
   width: 100%;
   max-width: 100rem;
+
+  animation: ${show} 0.5s;
+  transition: 0.5s;
 `;
 
 export const TagListWrapper = styled.div`

--- a/frontend/src/pages/DiscussionSubmitPage/DiscussionSubmitPage.styled.ts
+++ b/frontend/src/pages/DiscussionSubmitPage/DiscussionSubmitPage.styled.ts
@@ -1,4 +1,14 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const show = keyframes`
+  0% {
+    opacity: 0;
+    }
+
+  100% {
+    opacity: 1;
+  }
+`;
 
 export const DiscussionSubmitPageContainer = styled.div`
   display: flex;
@@ -7,4 +17,7 @@ export const DiscussionSubmitPageContainer = styled.div`
   margin: 4.5rem auto 0;
   width: 100%;
   max-width: 100rem;
+
+  animation: ${show} 0.5s;
+  transition: 0.5s;
 `;

--- a/frontend/src/pages/MissionDetailPage.styled.ts
+++ b/frontend/src/pages/MissionDetailPage.styled.ts
@@ -1,4 +1,14 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const show = keyframes`
+  0% {
+    opacity: 0;
+    }
+
+  100% {
+    opacity: 1;
+  }
+`;
 
 export const MissionDetailPageContainer = styled.div`
   width: 100rem;
@@ -6,4 +16,7 @@ export const MissionDetailPageContainer = styled.div`
   flex-direction: column;
   gap: 1rem;
   margin: 0 auto;
+
+  animation: ${show} 0.5s;
+  transition: 0.5s;
 `;

--- a/frontend/src/pages/MissionListPage/MissionListPage.styled.ts
+++ b/frontend/src/pages/MissionListPage/MissionListPage.styled.ts
@@ -1,4 +1,14 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const show = keyframes`
+  0% {
+    opacity: 0;
+    }
+
+  100% {
+    opacity: 1;
+  }
+`;
 
 export const MissionListPageContainer = styled.div`
   display: flex;
@@ -8,6 +18,9 @@ export const MissionListPageContainer = styled.div`
   margin: 5rem auto;
   width: 100%;
   max-width: 100rem;
+
+  animation: ${show} 0.5s;
+  transition: 0.5s;
 `;
 
 export const MissionListTitle = styled.h2`

--- a/frontend/src/pages/MissionSubmitPage.styled.ts
+++ b/frontend/src/pages/MissionSubmitPage.styled.ts
@@ -1,6 +1,19 @@
-import { styled } from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const show = keyframes`
+  0% {
+    opacity: 0;
+    }
+
+  100% {
+    opacity: 1;
+  }
+`;
 
 export const Container = styled.div`
   width: 100rem;
   margin: 0 auto;
+
+  animation: ${show} 0.5s;
+  transition: 0.5s;
 `;

--- a/frontend/src/pages/SolutionDetailPage/SolutionDetailPage.styled.ts
+++ b/frontend/src/pages/SolutionDetailPage/SolutionDetailPage.styled.ts
@@ -1,7 +1,20 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
+
+const show = keyframes`
+  0% {
+    opacity: 0;
+    }
+
+  100% {
+    opacity: 1;
+  }
+`;
 
 export const SolutionDetailPageContainer = styled.div`
   width: 100rem;
   margin: 0 auto;
   padding-bottom: 10rem;
+
+  animation: ${show} 0.5s;
+  transition: 0.5s;
 `;

--- a/frontend/src/pages/SolutionListPage/SolutionListPage.styled.ts
+++ b/frontend/src/pages/SolutionListPage/SolutionListPage.styled.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { keyframes } from 'styled-components';
 
 export const SolutionTitle = styled.h2`
   ${(props) => props.theme.font.heading1}
@@ -15,6 +15,16 @@ export const TitleWrapper = styled.div`
   gap: 1rem;
 `;
 
+const show = keyframes`
+  0% {
+    opacity: 0;
+    }
+
+  100% {
+    opacity: 1;
+  }
+`;
+
 export const SolutionListPageContainer = styled.div`
   width: 100%;
   max-width: 100rem;
@@ -23,4 +33,7 @@ export const SolutionListPageContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 3rem;
+
+  animation: ${show} 0.5s;
+  transition: 0.5s;
 `;

--- a/frontend/src/utils/debounce.ts
+++ b/frontend/src/utils/debounce.ts
@@ -1,0 +1,9 @@
+export const debounce = (action: () => void, delay: number) => {
+  let timer: ReturnType<typeof setTimeout>;
+  return function () {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      action();
+    }, delay);
+  };
+};


### PR DESCRIPTION
#### 구현 요약

1. 풀이 디테일 페이지에서 해시태그 클릭하면 해당 미션으로 navigate
2. 해시태그 호버 변환 속도 느리게 (0.2s -> 0.4s로 변경)

https://github.com/user-attachments/assets/f00ed835-fc98-41c8-8f62-fe27e3e35122




3. 스크롤 가장 위에 있을 땐 ScrollToTopButton이 안보이도록
- 스크롤 이벤트가 계속 실행되면서 window의 높이를 구하게 되는데, 이는 성능에 문제가 생길 것으로 판단하여 `debounce`를 적용했습니다!
- 스크롤 이벤트에 자주 사용되는 `throttle` 방식이 아닌 `debounce`를 사용한 이유는 스크롤이 멈췄을 때 현재 스크롤 위치를 구하기 위함입니다. `throttle`의 경우 이벤트가 진행되는 동안 지정된 시간마다 콜백 함수를 실행하는데, 스크롤이 끝나기 전에 콜백 함수를 실행한 뒤 지정된 시간 전에 스크롤이 끝났을 땐 더 이상 스크롤을 계산하지 않아 정확한 스크롤의 위치를 파악하기 어렵습니다. 
  - (자세하게 찾아보니 스크롤이 끝난 뒤에도 `throttle` 콜백 함수가 1회 더 실행되는 것이 맞다고 합니다..! 그런데 제가 작성했던 코드에서는 최상단에 도착해도 정확한 위치를 계산하지 못했어요 이 부분은 좀 더 확인이 필요할 것 같네용)
![image](https://github.com/user-attachments/assets/7181210e-a2be-482a-b7b9-ad57ccd0ed3a)

- `throttle` 사용 시

https://github.com/user-attachments/assets/c7acbf1f-f7e5-41ec-bd6b-a7e776f6ad2b

- `debounce` 사용 시

https://github.com/user-attachments/assets/f17959a0-3e8a-467a-a488-6f74643e864e




- 추가로 개인적으로 궁금해서 확인해봤는데요! 콜백 함수가 실행되는 횟수를 콘솔에서 확인해보니 같은 조건에서 `debounce`는 3회, `throttle`은 11회 실행되더라구요! `debounce`가 더 적게 실행되어 성능상 이점이 있어 보였습니다.
  - 조건 : 메인 페이지, 노트북 터치 패드로 한 번 길게 스크롤 → 스크롤이 멈춘 뒤 한 번 더 길게 스크롤 하여 페이지 하단까지 닿도록




4. 미션 상세, 풀이 상세, 디스커션 렌더 시 transition으로 부드럽게
- `GlobalStyles`의 body 부분에 transition이 걸려있지만 왜인지 작동하지 않았던 부분이라 .. 일단 모든 페이지에 트랜지션을 걸어놓았습니다😭


#### 연관 이슈

- close #707

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
