### PR TITLE
헤더 반응형 구현 (issue #701)

### DIFF
--- a/frontend/src/assets/images/hamburgerToggle.svg
+++ b/frontend/src/assets/images/hamburgerToggle.svg
@@ -1,0 +1,3 @@
+<svg width="100%" height="100%" viewBox="0 0 18 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 12H18V10H0V12ZM0 7H18V5H0V7ZM0 0V2H18V0H0Z" fill="#A7A7A7"/>
+</svg>

--- a/frontend/src/components/Header/Desktop.tsx
+++ b/frontend/src/components/Header/Desktop.tsx
@@ -1,0 +1,54 @@
+import { useLocation } from 'react-router-dom';
+import { ROUTES } from '@/constants/routes';
+import * as S from './Header.styled';
+import HeaderMenu from './HeaderMenu';
+import type { UserInfo } from '@/types/user';
+import { API_URL } from '@/apis/clients/develupClient';
+import { PATH } from '@/apis/paths';
+
+interface DesktopProps {
+  userInfo: UserInfo | undefined;
+  handleUserLogout: () => void;
+}
+
+export default function Desktop({ userInfo, handleUserLogout }: DesktopProps) {
+  const { pathname } = useLocation();
+
+  return (
+    <>
+      <S.Container>
+        <S.Wrapper>
+          <S.LeftPart>
+            <S.LogoWrapper to={ROUTES.main}>
+              <S.LogoImage />
+              <S.Logo> DEVEL UP</S.Logo>
+            </S.LogoWrapper>
+          </S.LeftPart>
+          <S.MenuWrapper>
+            <HeaderMenu name="미션" path={ROUTES.missionList} currentPath={pathname} />
+            <HeaderMenu name="풀이" path={ROUTES.solutions} currentPath={pathname} />
+            <HeaderMenu name="디스커션" path={ROUTES.discussions} currentPath={pathname} />
+          </S.MenuWrapper>
+          <S.RightPart>
+            {/* 아직 알림이 mock data라서 주석처리 해놓겠습니다 @프룬 */}
+            {/* {userInfo && <S.BellIcon onClick={handleToggleModal} />} */}
+            {userInfo && (
+              <HeaderMenu name="대시보드" path={ROUTES.dashboardHome} currentPath={pathname} />
+            )}
+            {!userInfo ? (
+              <a href={`${API_URL}${PATH.githubLogin}?next=${pathname}`}>
+                <S.LoginButton aria-label="클릭하면 깃허브 로그인으로 이동합니다.">
+                  로그인
+                </S.LoginButton>
+              </a>
+            ) : (
+              <S.LoginButton onClick={handleUserLogout}>로그아웃</S.LoginButton>
+            )}
+          </S.RightPart>
+        </S.Wrapper>
+      </S.Container>
+      {/* {isModalOpen && <NotiModal closeModal={handleModalClose} />} */}
+      <S.Spacer />
+    </>
+  );
+}

--- a/frontend/src/components/Header/Header.styled.ts
+++ b/frontend/src/components/Header/Header.styled.ts
@@ -1,6 +1,9 @@
 import Bell from '@/assets/images/bell.svg';
+import media from '@/styles/mediaQueries';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import HamburgerToggle from '@/assets/images/hamburgerToggle.svg';
+import LogoImg from '@/assets/images/logo.svg';
 
 export const Container = styled.nav`
   z-index: 100;
@@ -15,6 +18,11 @@ export const Container = styled.nav`
   align-items: center;
 
   white-space: nowrap;
+
+  ${media.medium`
+      opacity: 0;
+      pointer-events: none;
+    `}
 `;
 
 export const Wrapper = styled.div`
@@ -22,10 +30,16 @@ export const Wrapper = styled.div`
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
+
+  max-width: 100rem;
+  width: 100%;
+  padding: 0 1rem;
 `;
 
-export const LogoImg = styled.img`
-  width: 13rem;
+export const LogoImage = styled(LogoImg)`
+  width: 3rem;
+  height: 3rem;
+  cursor: pointer;
 `;
 
 export const Logo = styled.h1`
@@ -44,11 +58,16 @@ export const BellIcon = styled(Bell)`
 
 export const RightPart = styled.div`
   display: flex;
+  flex: 1;
   align-items: center;
+  justify-content: flex-end;
   gap: 2.3rem;
 `;
 
-export const LeftPart = styled.div``;
+export const LeftPart = styled.div`
+  display: flex;
+  flex: 1;
+`;
 
 export const LogoWrapper = styled(Link)`
   display: flex;
@@ -68,9 +87,17 @@ export const LoginButton = styled.button`
 
 export const MenuWrapper = styled.div`
   display: flex;
+  flex: 1;
   gap: 4.2rem;
+  justify-content: center;
 `;
 
+export const MenuTextLink = styled(Link)`
+  ${media.medium`
+      width: 100%;
+      text-align: center;
+      `}
+`;
 export const MenuText = styled.p<{ $isActive?: boolean }>`
   ${(props) => props.theme.font.body}
   color: ${({ $isActive, theme }) => ($isActive ? '' : theme.colors.grey400)};
@@ -80,4 +107,67 @@ export const MenuText = styled.p<{ $isActive?: boolean }>`
   &:hover {
     background-color: ${(props) => props.theme.colors.grey50};
   }
+`;
+
+//  Mobile
+
+export const MobileContainer = styled.nav`
+  opacity: 0;
+  pointer-events: none;
+
+  z-index: 100;
+  width: 100%;
+  position: fixed;
+  background: ${(props) => props.theme.colors.white};
+  top: 0;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
+
+  white-space: nowrap;
+  padding: 0 2rem;
+
+  ${media.medium`
+      opacity: 1;
+      pointer-events: auto;
+    `}
+`;
+
+export const HamburgerToggleIcon = styled(HamburgerToggle)`
+  width: 2.5rem;
+  color: ${(props) => props.theme.colors.grey400};
+  cursor: pointer;
+`;
+
+export const MobileWrapper = styled.div`
+  display: flex;
+  height: 6rem;
+  width: 100%;
+`;
+
+export const MobileLeft = styled.div`
+  display: flex;
+  flex: 1;
+`;
+
+export const MobileCenter = styled.div`
+  display: flex;
+  flex: 1;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ToggleMenu = styled.menu`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+
+  width: 100%;
+`;
+
+export const DashboardWrapper = styled.div`
+  width: fit-content;
 `;

--- a/frontend/src/components/Header/Header.styled.ts
+++ b/frontend/src/components/Header/Header.styled.ts
@@ -20,8 +20,7 @@ export const Container = styled.nav`
   white-space: nowrap;
 
   ${media.medium`
-      opacity: 0;
-      pointer-events: none;
+      display: none;
     `}
 `;
 
@@ -112,8 +111,7 @@ export const MenuText = styled.p<{ $isActive?: boolean }>`
 //  Mobile
 
 export const MobileContainer = styled.nav`
-  opacity: 0;
-  pointer-events: none;
+  display: none;
 
   z-index: 100;
   width: 100%;
@@ -121,7 +119,6 @@ export const MobileContainer = styled.nav`
   background: ${(props) => props.theme.colors.white};
   top: 0;
   left: 0;
-  display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
@@ -130,8 +127,7 @@ export const MobileContainer = styled.nav`
   padding: 0 2rem;
 
   ${media.medium`
-      opacity: 1;
-      pointer-events: auto;
+      display: block;
     `}
 `;
 

--- a/frontend/src/components/Header/HeaderMenu.tsx
+++ b/frontend/src/components/Header/HeaderMenu.tsx
@@ -1,18 +1,19 @@
-import { Link } from 'react-router-dom';
+import type { HTMLAttributes } from 'react';
 import * as S from './Header.styled';
 
-interface HeaderMenuProps {
+interface HeaderMenuProps extends HTMLAttributes<HTMLDivElement> {
   name: string;
   path: string;
   currentPath: string;
+  handleToggle?: () => void;
 }
 
-export default function HeaderMenu({ name, path, currentPath }: HeaderMenuProps) {
+export default function HeaderMenu({ name, path, currentPath, handleToggle }: HeaderMenuProps) {
   const isCurrentMenu = currentPath === path;
 
   return (
-    <Link to={path}>
+    <S.MenuTextLink to={path} onClick={handleToggle}>
       <S.MenuText $isActive={isCurrentMenu}>{name}</S.MenuText>
-    </Link>
+    </S.MenuTextLink>
   );
 }

--- a/frontend/src/components/Header/Mobile.tsx
+++ b/frontend/src/components/Header/Mobile.tsx
@@ -33,16 +33,6 @@ export default function Mobile({ userInfo, handleUserLogout }: MobileProps) {
           </S.MobileCenter>
 
           <S.RightPart>
-            {userInfo && (
-              <S.DashboardWrapper>
-                <HeaderMenu
-                  name="대시보드"
-                  path={ROUTES.dashboardHome}
-                  currentPath={pathname}
-                  handleToggle={handleToggle}
-                />
-              </S.DashboardWrapper>
-            )}
             {!userInfo ? (
               <a href={`${API_URL}${PATH.githubLogin}?next=${pathname}`}>
                 <S.LoginButton aria-label="클릭하면 깃허브 로그인으로 이동합니다.">
@@ -74,6 +64,14 @@ export default function Mobile({ userInfo, handleUserLogout }: MobileProps) {
               currentPath={pathname}
               handleToggle={handleToggle}
             />
+            {userInfo && (
+              <HeaderMenu
+                name="대시보드"
+                path={ROUTES.dashboardHome}
+                currentPath={pathname}
+                handleToggle={handleToggle}
+              />
+            )}
           </S.ToggleMenu>
         )}
       </S.MobileContainer>

--- a/frontend/src/components/Header/Mobile.tsx
+++ b/frontend/src/components/Header/Mobile.tsx
@@ -1,0 +1,82 @@
+import type { UserInfo } from '@/types/user';
+import * as S from './Header.styled';
+import HeaderMenu from './HeaderMenu';
+import { ROUTES } from '@/constants/routes';
+import { API_URL } from '@/apis/clients/develupClient';
+import { PATH } from '@/apis/paths';
+import { Link, useLocation } from 'react-router-dom';
+import { useState } from 'react';
+
+interface MobileProps {
+  userInfo: UserInfo | undefined;
+  handleUserLogout: () => void;
+}
+
+export default function Mobile({ userInfo, handleUserLogout }: MobileProps) {
+  const { pathname } = useLocation();
+  const [isToggleOpen, setIsToggleOpen] = useState(false);
+  const handleToggle = () => {
+    setIsToggleOpen(!isToggleOpen);
+  };
+
+  return (
+    <>
+      <S.MobileContainer>
+        <S.MobileWrapper>
+          <S.MobileLeft>
+            <S.HamburgerToggleIcon onClick={handleToggle} />
+          </S.MobileLeft>
+          <S.MobileCenter>
+            <Link to={ROUTES.main}>
+              <S.LogoImage />
+            </Link>
+          </S.MobileCenter>
+
+          <S.RightPart>
+            {userInfo && (
+              <S.DashboardWrapper>
+                <HeaderMenu
+                  name="대시보드"
+                  path={ROUTES.dashboardHome}
+                  currentPath={pathname}
+                  handleToggle={handleToggle}
+                />
+              </S.DashboardWrapper>
+            )}
+            {!userInfo ? (
+              <a href={`${API_URL}${PATH.githubLogin}?next=${pathname}`}>
+                <S.LoginButton aria-label="클릭하면 깃허브 로그인으로 이동합니다.">
+                  로그인
+                </S.LoginButton>
+              </a>
+            ) : (
+              <S.LoginButton onClick={handleUserLogout}>로그아웃</S.LoginButton>
+            )}
+          </S.RightPart>
+        </S.MobileWrapper>
+        {isToggleOpen && (
+          <S.ToggleMenu>
+            <HeaderMenu
+              name="미션"
+              path={ROUTES.missionList}
+              currentPath={pathname}
+              handleToggle={handleToggle}
+            />
+            <HeaderMenu
+              name="풀이"
+              path={ROUTES.solutions}
+              currentPath={pathname}
+              handleToggle={handleToggle}
+            />
+            <HeaderMenu
+              name="디스커션"
+              path={ROUTES.discussions}
+              currentPath={pathname}
+              handleToggle={handleToggle}
+            />
+          </S.ToggleMenu>
+        )}
+      </S.MobileContainer>
+    </>
+  );
+}

--- a/frontend/src/components/Header/index.tsx
+++ b/frontend/src/components/Header/index.tsx
@@ -1,54 +1,19 @@
-import { useLocation } from 'react-router-dom';
-import * as S from './Header.styled';
-import { ROUTES } from '@/constants/routes';
 // import NotiModal from './NotiModal';
-import { PATH } from '@/apis/paths';
 import useUserInfo from '@/hooks/useUserInfo';
-import HeaderMenu from './HeaderMenu';
 import useLogoutMutation from '@/hooks/useLogoutMutation';
-import { API_URL } from '@/apis/clients/develupClient';
-import Logo from '@/assets/images/logo.svg';
+import Desktop from './Desktop';
+import Mobile from './Mobile';
 // import useModal from '@/hooks/useModal';
 
 export default function Header() {
-  const { pathname } = useLocation();
   const { data: userInfo } = useUserInfo();
   const { handleUserLogout } = useLogoutMutation();
   // const { isModalOpen, handleModalClose, handleToggleModal } = useModal();
 
   return (
     <>
-      <S.Container>
-        <S.Wrapper>
-          <S.LeftPart>
-            <S.LogoWrapper to={ROUTES.main}>
-              <Logo width={30} height={30} />
-              <S.Logo> DEVEL UP</S.Logo>
-            </S.LogoWrapper>
-          </S.LeftPart>
-          <S.MenuWrapper>
-            <HeaderMenu name="미션" path={ROUTES.missionList} currentPath={pathname} />
-            <HeaderMenu name="풀이" path={ROUTES.solutions} currentPath={pathname} />
-            <HeaderMenu name="디스커션" path={ROUTES.discussions} currentPath={pathname} />
-          </S.MenuWrapper>
-          <S.RightPart>
-            {/* 아직 알림이 mock data라서 주석처리 해놓겠습니다 @프룬 */}
-            {/* {userInfo && <S.BellIcon onClick={handleToggleModal} />} */}
-            {userInfo && (
-              <HeaderMenu name="대시보드" path={ROUTES.dashboardHome} currentPath={pathname} />
-            )}
-            {!userInfo ? (
-              <a href={`${API_URL}${PATH.githubLogin}?next=${pathname}`}>
-                <S.LoginButton aria-label='클릭하면 깃허브 로그인으로 이동합니다.'>로그인</S.LoginButton>
-              </a>
-            ) : (
-              <S.LoginButton onClick={handleUserLogout}>로그아웃</S.LoginButton>
-            )}
-          </S.RightPart>
-        </S.Wrapper>
-      </S.Container>
-      {/* {isModalOpen && <NotiModal closeModal={handleModalClose} />} */}
-      <S.Spacer />
+      <Desktop userInfo={userInfo} handleUserLogout={handleUserLogout} />
+      <Mobile userInfo={userInfo} handleUserLogout={handleUserLogout} />
     </>
   );
 }

--- a/frontend/src/pages/DashboardPage/DashBoardPageLayout/DashBoardPageLayout.styled.ts
+++ b/frontend/src/pages/DashboardPage/DashBoardPageLayout/DashBoardPageLayout.styled.ts
@@ -1,15 +1,4 @@
-import styled, { keyframes } from 'styled-components';
-
-const show = keyframes`
-  0% {
-    opacity: 0;
-    }
-
-  100% {
-    opacity: 1;
-  }
-`;
-
+import styled from 'styled-components';
 import media from '@/styles/mediaQueries';
 
 export const Container = styled.div`

--- a/frontend/src/styles/mediaQueries.ts
+++ b/frontend/src/styles/mediaQueries.ts
@@ -1,9 +1,10 @@
 import { css, type CSSObject, type Interpolation } from 'styled-components';
 
-export type Breakpoints = 'small' | 'landingMedium' | 'large';
+export type Breakpoints = 'small' | 'medium' |'landingMedium' | 'large';
 
 export const breakpoints: Record<Breakpoints, string> = {
   small: '@media (max-width: 480px)',
+  medium: '@media (max-width: 768px)',
   landingMedium: '@media (max-width: 890px)',
   large: '@media (min-width: 481px)',
 };

--- a/frontend/src/styles/mediaQueries.ts
+++ b/frontend/src/styles/mediaQueries.ts
@@ -1,4 +1,4 @@
-https://github.com/woowacourse-teams/2024-devel-up/pull/708/conflict?name=frontend%252Fsrc%252Fpages%252FDashboardPage%252FDashBoardPageLayout%252FDashBoardPageLayout.styled.ts&ancestor_oid=eb208d08f3d30842411e036c48bbc47aa8569dd0&base_oid=1bdb26ca8bd9b7faf8dd3c04562b538488943063&head_oid=6b531fa3ff9e5a5deba24cd226b0752fe0c95a49import { css, type CSSObject, type Interpolation } from 'styled-components';
+import { css, type CSSObject, type Interpolation } from 'styled-components';
 
 export type Breakpoints = 'small' | 'medium' | 'landingMedium' | 'large';
 


### PR DESCRIPTION
#### 구현 요약


1. 헤더 반응형을 구현했습니다.
- 사용자 피드백
<img src="https://github.com/user-attachments/assets/505e5120-e8f2-4971-a252-105c6e0bfc30" width="50%" />

2. medium 사이즈 이하일 경우 `Mobile` 컴포넌트를, 그 이상의 크기일 경우 `Desktop` 컴포넌트를 보여줍니다.

```tsx
export default function Header() {
  // ...

  return (
    <>
      <Desktop userInfo={userInfo} handleUserLogout={handleUserLogout} />
      <Mobile userInfo={userInfo} handleUserLogout={handleUserLogout} />
    </>
  );
}

```

- Desktop 사이즈
![image](https://github.com/user-attachments/assets/ee37ef28-ba70-4467-add8-c2fcaa302b96)
![image](https://github.com/user-attachments/assets/9c798564-504e-4e9b-ab38-b7a1c675be18)

```ts
export const Container = styled.nav`
  z-index: 100;
  width: 100%;
  height: 6rem;
  position: fixed;
  background: ${(props) => props.theme.colors.white};
  top: 0;
  left: 0;
  display: flex;
  justify-content: center;
  align-items: center;

  white-space: nowrap;

  ${media.medium`
      display: none; // medium이하의 사이즈일 경우 display: none
    `}
`;

```

- Medium 사이즈
  - 화면 크기가 400px 이하일 때 대시보드 - 로그아웃 길이가 화면 너비에 비해 길어져 레이아웃이 깨지는 문제가 발생했습니다! 그래서 `대시보드` 메뉴를 드롭다운으로 옮겼어요
![image](https://github.com/user-attachments/assets/4014aed4-e0ae-4697-8b5e-53b365a8f4a9)
![image](https://github.com/user-attachments/assets/cc24c533-23ab-4adc-b265-ac232de2f0ed)

```ts
export const MobileContainer = styled.nav`
  display: none;

  z-index: 100;
  width: 100%;
  position: fixed;
  background: ${(props) => props.theme.colors.white};
  top: 0;
  left: 0;
  flex-direction: column;
  justify-content: space-between;
  align-items: center;

  white-space: nowrap;
  padding: 0 2rem;

  ${media.medium`
      display: block; // medium 이하의 사이즈에서 display 되도록
    `}
`;
```



https://github.com/user-attachments/assets/fa39c92e-c110-419c-8a8c-8ab3a691e327

- mobile header에서 hover 시 원래는 메뉴 이름의 너비에 맞게 색상이 들어갔는데, 이렇게 부분적으로만 색상이 있는 것보다 메뉴 1행 전체에 색상이 들어가는 것이 더 자연스러워서 위와 같이 구현했습니다.
  - 부분적으로만 색상이 있는 경우는 아래와 같이 나타납니다.
  ![image](https://github.com/user-attachments/assets/0a99a821-d87d-471e-85ef-696024be4443)
  - 개선 후 : 
  ![image](https://github.com/user-attachments/assets/c7c0a9ee-95b9-4c8a-86c2-bab14aa4d754)



#### 연관 이슈

- close #701

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
