### PR TITLE
디스커션 목록 조회 쿼리 개선 (issue #715)

### DIFF
--- a/backend/src/main/resources/db/migration/V5__add_mission_id_index.sql
+++ b/backend/src/main/resources/db/migration/V5__add_mission_id_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_mission_id ON mission_hash_tag(mission_id);


### PR DESCRIPTION
#### 구현 요약

디스커션 목록 조회 쿼리를 개선했습니다.
1. 쿼리 개선
2. 미션 아이디 인덱스 추가
    ```sql
     CREATE INDEX idx_mission_id ON mission_hash_tag(mission_id);
    ```
최종적으로 API 기준 `22359ms -> 734ms`로 `약 96.72%` 개선 되었습니다.

기존의 쿼리는 한 방 쿼리이기는 하지만 중복을 제거하기 위해 임시 테이블을 만들고 제거하는 과정에 많은 시간이 소요 되었습니다. 하지만 중복을 제거하지 않으면 Data Duplication이 일어나기 때문에 꼭 필요한 과정입니다. 그래서 필요한 디스커션 id만 중복 제거해서 가져온 뒤 필요한 모든 정보를 id를 통해 조회해보면 어떨까라는 의견이 나왔고 적용했습니다.

수정된 쿼리는 정보를 얻기 위해 쿼리를 두 번 날려야 합니다. 하지만 시간 차이가 22359ms에서 4737ms로 `약 78.81%` 발생합니다. 쿼리를 두 번 날리더라도 **유저에게 빠른 응답을 날리는 것이 더 중요하다고 생각합니다.**

추가로 수정된 쿼리에서 LEFT JOIN을 할 때 ht1_0 테이블은 m2_0.id = ht1_0.mission_id로 연결되고 있습니다. 실행 계획을 확인해보니 ht1_0 테이블에 mission_id 열에 대해 인덱스가 없었고 인덱스를 추가했습니다.
```sql
SELECT DISTINCT d1_0.id
FROM discussion d1_0
         LEFT JOIN mission m2_0 ON m2_0.id = d1_0.mission_id
         LEFT JOIN mission_hash_tag ht1_0 ON m2_0.id = ht1_0.mission_id
         LEFT JOIN discussion_hash_tag ht2_0 ON d1_0.id = ht2_0.discussion_id
ORDER BY d1_0.id DESC
LIMIT 892, 9;
```
#### 인덱스 추가 전 실행 계획
![image](https://github.com/user-attachments/assets/c05e6b38-2e25-48d5-b6ae-f93c4828b542)

#### 인덱스 추가 후 실행 계획
![image](https://github.com/user-attachments/assets/bbd51f7b-073c-403f-9eab-b828457dce74)

인덱스를 추가한 후 해당 쿼리에 대한 실행 시간은 3613.867 ms에서 63.396 ms로 `약 5599.85%` 감소했습니다.

#### 연관 이슈

- close #715

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
