### PR TITLE
리스트 반응형 적용 (issue #717)

### DIFF
--- a/frontend/src/components/DiscussionList/DiscussionList.styled.ts
+++ b/frontend/src/components/DiscussionList/DiscussionList.styled.ts
@@ -55,6 +55,7 @@ export const ItemRight = styled.div`
   align-items: center;
   gap: 1.7rem;
   width: 10.5rem;
+  margin: 0 1rem;
 
   color: ${(props) => props.theme.colors.grey400};
   ${(props) => props.theme.font.caption};

--- a/frontend/src/components/MissionList/MissionList.styled.ts
+++ b/frontend/src/components/MissionList/MissionList.styled.ts
@@ -1,3 +1,4 @@
+import media from '@/styles/mediaQueries';
 import styled, { keyframes } from 'styled-components';
 
 export const MissionListContainer = styled.div`
@@ -5,6 +6,7 @@ export const MissionListContainer = styled.div`
   flex-direction: column;
   gap: 5rem;
   margin: 0 auto;
+  padding: 0 1.5rem;
   margin-bottom: 10rem;
   padding-top: 6rem;
   width: fit-content;
@@ -29,12 +31,16 @@ export const MissionList = styled.ul`
   flex-wrap: wrap;
 
   display: flex;
-  width: 100rem;
-  column-gap: 5rem;
+  justify-content: space-between;
   row-gap: 3.6rem;
 
   animation: ${show} 0.5s;
   transition: 0.5s;
+
+  ${media.medium`
+    justify-content: center;
+    column-gap: 3rem;
+    `}
 `;
 
 export const MissionItemWrapper = styled.li``;

--- a/frontend/src/components/SolutionList/SolutionList.styled.ts
+++ b/frontend/src/components/SolutionList/SolutionList.styled.ts
@@ -1,3 +1,4 @@
+import media from '@/styles/mediaQueries';
 import styled, { keyframes } from 'styled-components';
 
 const show = keyframes`
@@ -14,10 +15,15 @@ export const SolutionList = styled.div`
   display: flex;
   max-width: 100rem;
 
-  column-gap: 5rem;
+  justify-content: space-between;
   row-gap: 3.6rem;
   flex-wrap: wrap;
 
   animation: ${show} 0.5s;
   transition: 0.5s;
+
+  ${media.medium`
+    justify-content: center;
+    column-gap: 3rem;
+    `}
 `;

--- a/frontend/src/components/common/Badge/Badge.styled.ts
+++ b/frontend/src/components/common/Badge/Badge.styled.ts
@@ -32,5 +32,5 @@ export const BadgeContainer = styled.div<BadgeContainerProps>`
   width: fit-content;
   padding: 0.4rem 0.8rem;
   border-radius: 0.4rem;
-  white-space: nowrap;
+  white-space: wrap;
 `;

--- a/frontend/src/components/common/Card/Card.styled.ts
+++ b/frontend/src/components/common/Card/Card.styled.ts
@@ -1,3 +1,4 @@
+import media from '@/styles/mediaQueries';
 import styled from 'styled-components';
 
 export const CardContainer = styled.div`
@@ -10,6 +11,10 @@ export const CardContainer = styled.div`
   &:hover {
     transform: scale(1.04);
   }
+
+  ${media.small`
+      width: 28rem;
+    `}
 `;
 
 export const Thumbnail = styled.img`
@@ -17,6 +22,10 @@ export const Thumbnail = styled.img`
   height: 21.9rem;
   object-fit: cover;
   border-radius: 0.8rem 0.8rem 0 0;
+
+  ${media.small`
+      width: 28rem;
+    `}
 `;
 
 export const Content = styled.div`

--- a/frontend/src/pages/DiscussionListPage/DiscussionListPage.styled.ts
+++ b/frontend/src/pages/DiscussionListPage/DiscussionListPage.styled.ts
@@ -15,6 +15,7 @@ export const DiscussionListPageContainer = styled.div`
   flex-direction: column;
   gap: 4.5rem;
   margin: 4.5rem auto 0;
+  padding: 0 1.5rem;
   width: 100%;
   max-width: 100rem;
 

--- a/frontend/src/pages/MainPage/MainPage.styled.tsx
+++ b/frontend/src/pages/MainPage/MainPage.styled.tsx
@@ -11,6 +11,8 @@ export const MissionListWrapper = styled.div`
   display: flex;
   flex-direction: column;
   margin: 0 auto;
+  padding: 0 1.5rem;
+  max-width: 100rem;
 `;
 
 export const MissionListTitle = styled.h2`

--- a/frontend/src/pages/MissionListPage/MissionListPage.styled.ts
+++ b/frontend/src/pages/MissionListPage/MissionListPage.styled.ts
@@ -16,6 +16,7 @@ export const MissionListPageContainer = styled.div`
   gap: 3rem;
 
   margin: 5rem auto;
+  padding: 0 1.5rem;
   width: 100%;
   max-width: 100rem;
 

--- a/frontend/src/pages/SolutionListPage/SolutionListPage.styled.ts
+++ b/frontend/src/pages/SolutionListPage/SolutionListPage.styled.ts
@@ -29,6 +29,7 @@ export const SolutionListPageContainer = styled.div`
   width: 100%;
   max-width: 100rem;
   margin: 5rem auto;
+  padding: 0 1.5rem;
 
   display: flex;
   flex-direction: column;

--- a/frontend/src/styles/GlobalLayout.tsx
+++ b/frontend/src/styles/GlobalLayout.tsx
@@ -4,4 +4,5 @@ export const GlobalLayout = styled.div`
   height: auto;
   min-height: 100vh;
   padding-bottom: 10rem;
+  min-width: 28rem;
 `;


### PR DESCRIPTION
#### 구현 요약

리스트 반응형을 적용했습니다. (메인, 미션, 풀이, 디스커션)
- 메인 페이지의 미션 리스트 반응형 적용
- 미션 리스트 반응형 적용
- 풀이 리스트 반응형 적용
- 디스커션 리스트 반응형 적용

### 개선하면 좋을 부분
- 메인, 미션, 풀이 리스트가 거의 유사한 형태로 되어있는데, 이 부분을 `합성 컴포넌트`로 추상화하면 좋을 것 같아요. CSS 적용을 하려니 비슷한 코드들을 서로 다른 컴포넌트에 적용하려고 하니 불필요한 작업이라는 생각이 들었습니다🥲
- 합성 컴포넌트로 개선해본다면, `title` `subtitle` `missionTagList` `hashtagList` `content` 부분으로 나누면 좋을 것 같습니다~!!

![image](https://github.com/user-attachments/assets/d5478093-a26f-479f-83e7-05147b593a8c)
![image](https://github.com/user-attachments/assets/1bb73fcb-83c2-4b80-8b4e-0f5144b552ae)


#### 연관 이슈

- close #717

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
