### PR TITLE
본문으로 바로가기 버튼 안보이도록 수정 (issue #719)

### DIFF
--- a/frontend/src/App.styled.ts
+++ b/frontend/src/App.styled.ts
@@ -5,19 +5,18 @@ export const Container = styled.div`
 `;
 
 export const SkipTag = styled.a`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 10rem;
-  height: 8rem;
-  padding: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
   &:focus {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 10rem;
+    height: 8rem;
+    padding: 0;
+    overflow: hidden;
+    white-space: nowrap;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     z-index: 1000;
     background: ${(props) => props.theme.colors.primary500};
     color: ${(props) => props.theme.colors.white};


### PR DESCRIPTION
#### 구현 요약

웹 접근성을 위해 생성했던 `본문으로 바로가기` 버튼이 보이지 않도록 수정했습니다 (포커싱 되었을 때만 보이도록)
[이전 PR 참고](https://github.com/woowacourse-teams/2024-devel-up/pull/706)

- Mac 기종에서는 브라우저 최상단에서 스크롤을 올렸을 때 튕겨지는 애니메이션과 함께 스크롤이 더 올라갈 수 있습니다.
- 따라서 `Header`에 가려져있던 `본문으로 바로가기` 버튼이 화면에 보여집니다.
  - `윈도우에서는 안보였는데..! 역시 다양한 기종에서 테스트해봐야겠군요🫠`
- 이를 해결하기 위해, `focus` 상태에서만 CSS 스타일이 적용되도록 수정했습니다.

#### 연관 이슈

- close #719

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
