### PR TITLE
반응형 디자인 수정 (issue #730)

### DIFF
--- a/frontend/src/components/DiscussionList/DiscussionList.styled.ts
+++ b/frontend/src/components/DiscussionList/DiscussionList.styled.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import CommentCount from '@/assets/images/comment-count.svg';
+import media from '@/styles/mediaQueries';
 
 // Content
 
@@ -26,20 +27,28 @@ export const ItemContainer = styled.div`
   &:hover {
     transform: scale(1.01);
   }
+
+  ${media.small`
+      padding: 1.4rem 2rem;
+    `}
 `;
 
 export const BadgeWrapper = styled.div`
   display: flex;
   gap: 0.7rem;
+  flex-wrap: wrap;
 `;
 
 export const ContentWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  flex: 1;
 `;
 
 export const Title = styled.p`
+  width: 100%;
+  word-break: break-all;
   color: ${(props) => props.theme.colors.black};
   ${(props) => props.theme.font.body}
 `;

--- a/frontend/src/components/common/Badge/Badge.styled.ts
+++ b/frontend/src/components/common/Badge/Badge.styled.ts
@@ -1,6 +1,7 @@
 import styled, { css } from 'styled-components';
 import type { BadgeVariant } from '.';
 import type { DefaultTheme } from 'styled-components/dist/types';
+import media from '@/styles/mediaQueries';
 
 interface BadgeContainerProps {
   $variant: BadgeVariant;
@@ -32,5 +33,12 @@ export const BadgeContainer = styled.div<BadgeContainerProps>`
   width: fit-content;
   padding: 0.4rem 0.8rem;
   border-radius: 0.4rem;
-  white-space: wrap;
+  white-space: nowrap;
+  -webkit-line-clamp: 1;
+  text-overflow: ellipsis;
+  overflow: hidden;
+
+  ${media.small`
+      max-width: 10rem;
+    `}
 `;

--- a/frontend/src/components/common/Card/Card.styled.ts
+++ b/frontend/src/components/common/Card/Card.styled.ts
@@ -30,6 +30,6 @@ export const Content = styled.div`
   justify-content: space-between;
 
   ${media.medium`
-    min-height: 15rem;
+    min-height: 15.3rem;
     `}
 `;

--- a/frontend/src/components/common/TagList/TagList.styled.ts
+++ b/frontend/src/components/common/TagList/TagList.styled.ts
@@ -4,6 +4,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 0.7rem;
+  flex-wrap: wrap;
 `;
 
 export const Label = styled.p`

--- a/frontend/src/pages/MainPage/MainPage.styled.tsx
+++ b/frontend/src/pages/MainPage/MainPage.styled.tsx
@@ -13,6 +13,7 @@ export const MissionListWrapper = styled.div`
   margin: 0 auto;
   padding: 0 1.5rem;
   max-width: 100rem;
+  width: 100%;
 `;
 
 export const MissionListTitle = styled.h2`


### PR DESCRIPTION
#### 구현 요약

랜딩 페이지, 디스커션 반응형 디자인을 수정했습니다.
- 랜딩 페이지 width를 100%로 수정
- Card 컴포넌트가 medium 크기 이하일 때 min-height를 15 -> 15.3rem으로 조정
- DiscussionList가 small 사이즈일 경우 badge와 title 길이로 인해 레이아웃이 깨지는 현상이 발생
  - `word-break`와 `flex-wrap` 등을 활용하여 레이아웃 조정 
  
- DiscussionList small 사이즈 이미지
![image](https://github.com/user-attachments/assets/cc6b6763-ea5d-4ca4-9109-2738a13c7e21)


### 

#### 연관 이슈

- close #730

#### 참고

코드 리뷰에 `RCA 룰`을 적용할 시 참고해주세요.

| 헤더                  | 설명                             |
|---------------------|--------------------------------|
| R (Request Changes) | 적극적으로 반영을 고려해주세요               |
| C (Comment)         | 웬만하면 반영해주세요                    |
| A (Approve)         | 반영해도 좋고, 넘어가도 좋습니다. 사소한 의견입니다. |
